### PR TITLE
Added identity decoding also for AltitudeReplies

### DIFF
--- a/main/traffic.go
+++ b/main/traffic.go
@@ -1276,7 +1276,7 @@ func esListen() {
 				ti.OnGround = bool(*newTi.OnGround)
 			}
 
-			if (newTi.Tail != nil) && ((newTi.DF == 17) || (newTi.DF == 18) || (newTi.DF == 21)) { // DF=17 or DF=18, Type Code 1-4 , DF=21 Identity Reply
+			if (newTi.Tail != nil) && ((newTi.DF == 17) || (newTi.DF == 18) || (newTi.DF == 20) || (newTi.DF == 21)) { // DF=17 or DF=18, Type Code 1-4 , DF=20 Altitude Reply (often with Ident in Comm-B) DF=21 Identity Reply
 				ti.Tail = *newTi.Tail
 				ti.Tail = strings.Trim(ti.Tail, " ") // remove extraneous spaces
 			}


### PR DESCRIPTION
dump1090-fa now also decodes the COMM-B block for AltitudeReply in the right manner. Very often the registration is provided in such an AltitudeReply. So use it for tail identification if provided in the Mode-S message.