### PR TITLE
Second wifi needs a separate wpa_supplicant.conf

### DIFF
--- a/image/interfaces
+++ b/image/interfaces
@@ -37,7 +37,7 @@ iface p2p-wlan0-0 inet static
 
 # allow-hotplug wlan1
 # iface wlan1 inet manual
-#     wpa-roam /etc/wpa_supplicant/wpa_supplicant.conf
+#     wpa-roam /etc/wpa_supplicant/wpa_supplicant_wlan1.conf
 # iface name_of_WPA_Config inet dhcp
 # iface name_of_other_WPA_Config inet dhcp
 
@@ -45,7 +45,7 @@ iface p2p-wlan0-0 inet static
 ## End of interfaces
 
 
-#contents of wpa_supplicant.conf
+#contents of /etc/wpa_supplicant/wpa_supplicant_wlan1.conf
 #############################################################
 # ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 # update_config=1

--- a/image/interfaces.template
+++ b/image/interfaces.template
@@ -40,7 +40,7 @@ iface p2p-wlan0-0 inet static
 
 # allow-hotplug wlan1
 # iface wlan1 inet manual
-#     wpa-roam /etc/wpa_supplicant/wpa_supplicant.conf
+#     wpa-roam /etc/wpa_supplicant/wpa_supplicant_wlan1.conf
 # iface name_of_WPA_Config inet dhcp
 # iface name_of_other_WPA_Config inet dhcp
 
@@ -48,7 +48,7 @@ iface p2p-wlan0-0 inet static
 ## End of interfaces
 
 
-#contents of wpa_supplicant.conf
+#contents of /etc/wpa_supplicant/wpa_supplicant_wlan1.conf
 #############################################################
 # ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 # update_config=1


### PR DESCRIPTION
For the setup of a second wifi with a dongle the config files suggest the necessary configuration. But the file wpa_supplicant.conf exists already for the first wifi thus we need a separate config file for the second one. I changed the suggested file name accordingly in the comments to wpa_supplicant_wlan1.conf  