### PR TITLE
Second wifi needs a separate wpa_supplicant.conf

### DIFF
--- a/image/interfaces
+++ b/image/interfaces
@@ -29,9 +29,9 @@ iface p2p-wlan0-0 inet static
 ##               Custom settings not for novice users!!!!!!  
 ##               Modify at your own risk!!!!!!!!!!!!!!!!!!!
 ##
-##   Second Wifi Dongle for local work and internet access
-##   This template is for adding a second wifi dongle to your PI for internet access while debugging
-##     Modify /etc/wpa_supplicant/wpa_supplicant.conf with your settings also( see below )
+##  Second Wifi Dongle for local work and internet access
+##  This template is for adding a second wifi dongle to your PI for internet access while debugging
+##  You need to create a file /etc/wpa_supplicant/wpa_supplicant_wlan1.conf with your settings (see below)
 ##
 ##  Uncomment the following lines as needed. 
 

--- a/image/interfaces
+++ b/image/interfaces
@@ -37,7 +37,7 @@ iface p2p-wlan0-0 inet static
 
 # allow-hotplug wlan1
 # iface wlan1 inet manual
-#     wpa-roam /etc/wpa_supplicant/wpa_supplicant.conf
+#     wpa-roam /etc/wpa_supplicant/wpa_supplicant_wlan1.conf
 # iface name_of_WPA_Config inet dhcp
 # iface name_of_other_WPA_Config inet dhcp
 
@@ -45,7 +45,7 @@ iface p2p-wlan0-0 inet static
 ## End of interfaces
 
 
-#contents of wpa_supplicant.conf
+#contents of /etc/wpa_supplicant/wpa_supplicant_wlan1.conf
 #############################################################
 # ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 # update_config=1

--- a/image/interfaces.template
+++ b/image/interfaces.template
@@ -40,7 +40,7 @@ iface p2p-wlan0-0 inet static
 
 # allow-hotplug wlan1
 # iface wlan1 inet manual
-#     wpa-roam /etc/wpa_supplicant/wpa_supplicant.conf
+#     wpa-roam /etc/wpa_supplicant/wpa_supplicant_wlan1.conf
 # iface name_of_WPA_Config inet dhcp
 # iface name_of_other_WPA_Config inet dhcp
 
@@ -48,7 +48,7 @@ iface p2p-wlan0-0 inet static
 ## End of interfaces
 
 
-#contents of wpa_supplicant.conf
+#contents of /etc/wpa_supplicant/wpa_supplicant_wlan1.conf
 #############################################################
 # ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 # update_config=1

--- a/image/interfaces.template
+++ b/image/interfaces.template
@@ -32,9 +32,9 @@ iface p2p-wlan0-0 inet static
 ##               Custom settings not for novice users!!!!!!  
 ##               Modify at your own risk!!!!!!!!!!!!!!!!!!!
 ##
-##   Second Wifi Dongle for local work and internet access
-##   This template is for adding a second wifi dongle to your PI for internet access while debugging
-##     Modify /etc/wpa_supplicant/wpa_supplicant.conf with your settings also( see below )
+##  Second Wifi Dongle for local work and internet access
+##  This template is for adding a second wifi dongle to your PI for internet access while debugging
+##  You need to create a file /etc/wpa_supplicant/wpa_supplicant_wlan1.conf with your settings (see below)
 ##
 ##  Uncomment the following lines as needed. 
 


### PR DESCRIPTION
One comment was forgotten to be updated. Changed for clarification. 
This setup leaves one open issue: the second wifi only comes alive when the dongle is plugged in _after_ the system has booted. When the dongle is plugged in on boot time the config is not read and the wifi not connected.