### PR TITLE
Fancontrol with PID

### DIFF
--- a/fancontrol_main/fancontrol.go
+++ b/fancontrol_main/fancontrol.go
@@ -10,15 +10,16 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+	"math"
 
 	"github.com/b3nn0/stratux/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/takama/daemon"
+	"github.com/felixge/pidctrl"
+	"github.com/stianeikeland/go-rpio/v4"
 )
 
-// #include <wiringPi.h>
-// #cgo LDFLAGS: -lwiringPi
 import "C"
 
 // Initialize Prometheus metrics.
@@ -26,6 +27,11 @@ var (
 	currentTemp = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "current_temp",
 		Help: "Current CPU temp.",
+	})
+
+	currentPWM = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "current_pwm",
+		Help: "Current PWM Value",
 	})
 
 	totalFanOnTime = prometheus.NewCounterVec(
@@ -49,25 +55,27 @@ const (
 	configLocation = "/boot/stratux.conf"
 
 	// CPU temperature target, degrees C
-	defaultTempTarget = 50.
-	hysteresis        = float32(1.)
+	defaultTempTarget = 55.
 
-	pwmClockDivisor = 100
+	/* Minimum duty cycle in % is the point below which the fan  */
+	/* stops running nicely from a running situation */
+	defaultPwmDutyMin = 50
 
-	/* Minimum duty cycle is the point below which the fan does
-	/* not spin. This depends on both your fan and the switching
-	/* transistor used. */
-	defaultPwmDutyMin = 1
+	/* Maximum duty for PWM controller */
 	pwmDutyMax        = 100
+	pwmFanFrequency   = 3000
 
 	// Temperature at which we give up attempting active fan speed control and set it to full speed.
 	failsafeTemp = 65
 
 	// how often to update
-	delaySeconds = 30
+	updateDelayMS = 5000
 
-	// GPIO-1/BCM "18"/Pin 12 on a Raspberry Pi 3
-	defaultPin = 1
+	// start delay of the fan to start the fan to 80% to give the fan a kick to start spinning
+	PWMDuty80PStartDelay = 500
+
+	// GPIO-1/BCM "18"/Pin 12 on a Rev 2 and 3,4 Raspberry Pi   
+	defaultPin = 18
 
 	// name of the service
 	name        = "fancontrol"
@@ -78,12 +86,13 @@ const (
 )
 
 type FanControl struct {
-	TempTarget     float32
-	TempCurrent    float32
-	PWMDutyMin     int
-	PWMDutyMax     int
-	PWMDutyCurrent int
-	PWMPin         int
+	TempTarget           float64
+	TempCurrent          float64
+	PWMDutyMin           uint32
+	PWMDutyMax           uint32
+	PWMDuty80PStartDelay uint32
+	PWMDutyCurrent       uint32
+	PWMPin               int
 }
 
 var myFanControl FanControl
@@ -98,77 +107,110 @@ func updateStats() {
 		<-updateTicker.C
 		totalUptime.With(prometheus.Labels{"all": "all"}).Inc()
 		currentTemp.Set(float64(myFanControl.TempCurrent))
+		currentPWM.Set(float64(myFanControl.PWMDutyCurrent))
 		if myFanControl.PWMDutyCurrent > 0 {
 			totalFanOnTime.With(prometheus.Labels{"all": "all"}).Inc()
 		}
 	}
 }
 
+func fmap( x, in_min, in_max, out_min, out_max float64) float64 {
+	return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
+
+
+
 func fanControl() {
-	prometheus.MustRegister(currentTemp)
-	prometheus.MustRegister(totalFanOnTime)
-	prometheus.MustRegister(totalUptime)
-
-	go updateStats()
-
-	cPin := C.int(myFanControl.PWMPin)
-
-	C.wiringPiSetup()
-
-	// Power on "test". Allows the user to verify that their fan is working.
-	C.pinMode(cPin, C.OUTPUT)
-	C.digitalWrite(cPin, C.HIGH)
-	time.Sleep(5 * time.Second)
-	C.digitalWrite(cPin, C.LOW)
-
-	
+	myFanControl.PWMDutyMax = pwmDutyMax
+	myFanControl.PWMDuty80PStartDelay = PWMDuty80PStartDelay
+	pWMDutyMinMapped := math.Ceil(fmap(float64(myFanControl.PWMDutyMin), 0.0, 100.0, 0, float64(myFanControl.PWMDutyMax)))
 	myFanControl.TempCurrent = 0
+	myFanControl.PWMDutyCurrent = 0
+	updateControlDelay := time.NewTicker(updateDelayMS * time.Millisecond)
+
+	// Monitor Temperature
 	go common.CpuTempMonitor(func(cpuTemp float32) {
 		if common.IsCPUTempValid(cpuTemp) {
-			myFanControl.TempCurrent = cpuTemp
+			myFanControl.TempCurrent = float64(cpuTemp)
 		}
 	})
 
-	myFanControl.PWMDutyCurrent = 0
+	// Open Raspberry GPIO pins		
+	err := rpio.Open()
+	if err != nil {
+			os.Exit(1)
+	}
+	defer rpio.Close()
 
-	delay := time.NewTicker(delaySeconds * time.Second)
+	// Set PWM Mode
+	pin := rpio.Pin(myFanControl.PWMPin)
+	pin.Mode(rpio.Pwm)
+	pin.Freq(pwmFanFrequency)
+ 
+	// Fan test function
+	turnOnFanTest := func () {
+		pin.DutyCycle(myFanControl.PWMDutyMax, myFanControl.PWMDutyMax)
+		time.Sleep(time.Duration(myFanControl.PWMDuty80PStartDelay) * time.Millisecond)	
+		pin.DutyCycle(uint32(pWMDutyMinMapped), myFanControl.PWMDutyMax)
+		time.Sleep(10 * time.Second)
+	}
 
+	// Power on "test". Allows the user to verify that their fan is working at the selected minimum duty cycle
+	// Turns on the fan at minimum duty for 10 seconds. User should see that the fan keeps running all the time
+	turnOnFanTest()
+
+	// Start Prometheus		
+	prometheus.MustRegister(currentTemp)
+	prometheus.MustRegister(currentPWM)
+	prometheus.MustRegister(totalFanOnTime)
+	prometheus.MustRegister(totalUptime)
+	go updateStats()
+
+	// Create a PID controller
+	pidControl := pidctrl.NewPIDController(0.2, 0.2, 0.1)
+	pidControl.SetOutputLimits(-100, 0.0)
+	pidControl.Set(myFanControl.TempTarget)
+
+	var lastPWMControlValue float64 = 0.0
 	for {
-		// Make sure we have 10 fanspeed steps, but if it's more than 90% duty cycle, we just increase by one every time
-		pwmDutyStep := (myFanControl.PWMDutyMax - myFanControl.PWMDutyMin) / 10.0
-		if pwmDutyStep < 1 {
-			pwmDutyStep = 1
+
+		// Update the PID controller.
+		pidValueOut := -pidControl.UpdateDuration(myFanControl.TempCurrent, updateDelayMS * time.Millisecond)
+
+		// If fan is starting up eg from 0 to some value, start it up for myFanControl.PWMDuty80PStartDelay at 80%
+		if (lastPWMControlValue <=5.0 && pidValueOut>5.0) {
+			log.Println("Starting up fan for" ,myFanControl.PWMDuty80PStartDelay, "ms")
+			pin.DutyCycle(myFanControl.PWMDutyMax, myFanControl.PWMDutyMax)
+			time.Sleep(time.Duration(myFanControl.PWMDuty80PStartDelay) * time.Millisecond)
 		}
 
-		if myFanControl.TempCurrent > (myFanControl.TempTarget + hysteresis) {
-			myFanControl.PWMDutyCurrent = common.IMax(common.IMin(myFanControl.PWMDutyMax, myFanControl.PWMDutyCurrent+pwmDutyStep), myFanControl.PWMDutyMin)
-		} else if myFanControl.TempCurrent < (myFanControl.TempTarget - hysteresis) {
-			myFanControl.PWMDutyCurrent = common.IMax(myFanControl.PWMDutyCurrent-pwmDutyStep, 0)
-			if myFanControl.PWMDutyCurrent < myFanControl.PWMDutyMin {
-				myFanControl.PWMDutyCurrent = myFanControl.PWMDutyMin
-			}
+		// Calculate the duty cycle appropriate for current PWM configuration
+		pwmDutyMapped := uint32(fmap(pidValueOut, 0.0, 100.0, pWMDutyMinMapped, float64(myFanControl.PWMDutyMax)))
+
+		log.Println(myFanControl.TempCurrent, " ", pwmDutyMapped, " ",lastPWMControlValue, " ", pidValueOut)
+		if (pidValueOut > 5.0) {
+			myFanControl.PWMDutyCurrent = pwmDutyMapped
+		} else {
+			myFanControl.PWMDutyCurrent = 0
 		}
-		//log.Println(myFanControl.TempCurrent, " ", myFanControl.PWMDutyCurrent)
-		C.pwmSetMode(C.PWM_MODE_MS)
-		C.pinMode(cPin, C.PWM_OUTPUT)
-		C.pwmSetRange(C.uint(myFanControl.PWMDutyMax))
-		C.pwmSetClock(pwmClockDivisor)
-		C.pwmWrite(cPin, C.int(myFanControl.PWMDutyCurrent))
+		pin.DutyCycle(myFanControl.PWMDutyCurrent, myFanControl.PWMDutyMax)
+
+		lastPWMControlValue = pidValueOut
+
 		select {
-		case <-delay.C:
-			if myFanControl.PWMDutyCurrent == myFanControl.PWMDutyMax && myFanControl.TempCurrent >= failsafeTemp {
-				// Reached the maximum temperature. We stop using PWM control and set the fan to "on" permanently.
-				break
-			}
-		case <-configChan:
-			// Make sure we don't change speed again immediately
-			myFanControl.TempCurrent = myFanControl.TempTarget
+			case <-updateControlDelay.C:
+				break;
+			case <-configChan:
+				pidControl.Set(myFanControl.TempTarget)
+				pWMDutyMinMapped = math.Ceil(fmap(float64(myFanControl.PWMDutyMin), 0.0, 100.0, 0, float64(myFanControl.PWMDutyMax)))
+				// set lastPWMControlValue so we go through a cycle of starting the fan
+				lastPWMControlValue = 0
+				turnOnFanTest()
 		}
 	}
 
-	// Default to "ON".
-	C.pinMode(cPin, C.OUTPUT)
-	C.digitalWrite(cPin, C.HIGH)
+	// Default to "ON" when we bail out
+	pin.DutyCycle(myFanControl.PWMDutyMax, myFanControl.PWMDutyMax)
 }
 
 // Service has embedded daemon
@@ -181,7 +223,7 @@ func (service *Service) Manage() (string, error) {
 
 	tempTarget := flag.Float64("temp", defaultTempTarget, "Target CPU Temperature, degrees C")
 	pwmDutyMin := flag.Int("minduty", defaultPwmDutyMin, "Minimum PWM duty cycle")
-	pin := flag.Int("pin", defaultPin, "PWM pin (wiringPi numbering)")
+	pin := flag.Int("pin", defaultPin, "PWM pin (BCM numbering)")
 	flag.Parse()
 
 	usage := "Usage: " + name + " install | remove | start | stop | status"
@@ -204,9 +246,8 @@ func (service *Service) Manage() (string, error) {
 		}
 	}
 
-	myFanControl.TempTarget = float32(*tempTarget)
-	myFanControl.PWMDutyMin = *pwmDutyMin
-	myFanControl.PWMDutyMax = pwmDutyMax
+	myFanControl.TempTarget = float64(*tempTarget)
+	myFanControl.PWMDutyMin = uint32(*pwmDutyMin)
 	myFanControl.PWMPin = *pin
 
 	readSettings()
@@ -231,7 +272,6 @@ func (service *Service) Manage() (string, error) {
 			return "Daemon was interrupted by system signal", nil
 		} else if (killSignal == syscall.SIGUSR1) {
 			readSettings()
-			myFanControl.PWMDutyCurrent = myFanControl.PWMDutyMin
 			configChan<-true
 		} else {
 			return "Daemon was killed", nil

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/b3nn0/goflying v0.0.0-20210424141101-d83dac8fdc36
 	github.com/dustin/go-humanize v1.0.0
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
+	github.com/felixge/pidctrl v0.0.0-20160307080219-7b13bcae7243
 	github.com/gansidui/geohash v0.0.0-20141019080235-ebe5ba447f34
 	github.com/jpoirier/gortlsdr v2.10.0+incompatible
 	github.com/kellydunn/golang-geo v0.7.0
@@ -15,6 +16,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.6
 	github.com/prometheus/client_golang v1.10.0
 	github.com/ricochet2200/go-disk-usage v0.0.0-20150921141558-f0d1b743428f
+	github.com/stianeikeland/go-rpio/v4 v4.5.0
 	github.com/stratux/serial v0.0.0-19700101022104-87f23b1d3198
 	github.com/takama/daemon v1.0.0
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
@@ -22,4 +24,5 @@ require (
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/net v0.0.0-20210326220855-61e056675ecf
 	gonum.org/v1/plot v0.9.0
+	gotest.tools/v3 v3.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/pidctrl v0.0.0-20160307080219-7b13bcae7243 h1:QMnlBy37k7MuFqwzUQsbsALRyoKQidWlOv5zNUmqj3w=
+github.com/felixge/pidctrl v0.0.0-20160307080219-7b13bcae7243/go.mod h1:YjeiQT/MWPDtPKgk/UAVJ9ZvZLSczA9gobU202W8gPY=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -299,6 +301,9 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/stianeikeland/go-rpio/v4 v4.5.0 h1:9jkc3cQor8gd40GeXVfcWI4mlZTTyXG6yROZCpKdV0c=
+github.com/stianeikeland/go-rpio/v4 v4.5.0/go.mod h1:A3GvHxC1Om5zaId+HqB3HKqx4K/AqeckxB7qRjxMK7o=
 github.com/stratux/serial v0.0.0-19700101022104-87f23b1d3198 h1:oK0CezUdK1uo3P4aboNpRkdErS4sTOUk50eW3qaqgeA=
 github.com/stratux/serial v0.0.0-19700101022104-87f23b1d3198/go.mod h1:i4vrHzYiaNeMMsal0bm/fq/MzXwQIB4zxBi9kJtntKg=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
@@ -443,6 +448,7 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190927191325-030b2cf1153e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -500,6 +506,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -474,9 +474,9 @@ input.ng-invalid:not(.grayout){
 	}
 	.sidebar-right-in .app {
 		width: auto;
-		-webkit-transform: translate3d(-320px, 0, 0)!important;
-		-moz-transform: translate3d(-320px, 0, 0)!important;
-		transform: translate3d(-320px, 0, 0)!important;
+		-webkit-transform: translate3d(-300px, 0, 0)!important;
+		-moz-transform: translate3d(-300px, 0, 0)!important;
+		transform: translate3d(-300px, 0, 0)!important;
 		position: relative;
 		-webkit-transition: -webkit-transform 0 ease;
 		-moz-transition: -moz-transform 0 ease;

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -474,9 +474,9 @@ input.ng-invalid:not(.grayout){
 	}
 	.sidebar-right-in .app {
 		width: auto;
-		-webkit-transform: translate3d(-300px, 0, 0)!important;
-		-moz-transform: translate3d(-300px, 0, 0)!important;
-		transform: translate3d(-300px, 0, 0)!important;
+		-webkit-transform: translate3d(-320px, 0, 0)!important;
+		-moz-transform: translate3d(-320px, 0, 0)!important;
+		transform: translate3d(-320px, 0, 0)!important;
 		position: relative;
 		-webkit-transition: -webkit-transform 0 ease;
 		-moz-transition: -moz-transform 0 ease;

--- a/web/plates/settings-help.html
+++ b/web/plates/settings-help.html
@@ -35,9 +35,10 @@
         You only have to do this once.  The settings for this sensor will be saved for future flights.</p>
     <p>The direction of gravity is used to determine the forward orientation.</p>
     <p>To find your <strong>Minimum fan duty cycle %</strong> follow these instructions:<br>
-        Start with a value of 50% and wait untill the fan spins up and watch what happens after:<br>
-        - When he fan stops running again or does not run smooth increase the % value.<br> 
-        - When it runs smooth and you think it can run slower, decrease the value.</p>
+        Start with a value of 50% and wait untill the fan spins up and watch what happens after<br>
+        - When he fan stops running again or does not run smooth increase the % value untill it spins up, then lower again.<br> 
+        - When it runs smooth and you think it can run slower, decrease the value.<br />
+        The goal is to ensure the fan runs smooth at lowest RPM without the tendency to go off and with minimum noise.</p>
 
     <p>GLoad Limits allows the user to set which limits will show on the G Meter on the GPS/AHRS page.
         Enter a space-separated list of G limits, e.g. "-1.76 4.4".</p>

--- a/web/plates/settings-help.html
+++ b/web/plates/settings-help.html
@@ -34,6 +34,10 @@
     <p>The calibration process determines which sensor direction will be forward.
         You only have to do this once.  The settings for this sensor will be saved for future flights.</p>
     <p>The direction of gravity is used to determine the forward orientation.</p>
+    <p>To find your <strong>Minimum fan duty cycle %</strong> follow these instructions:<br>
+        Start with a value of 50% and wait untill the fan spins up and watch what happens after:<br>
+        - When he fan stops running again or does not run smooth increase the % value.<br> 
+        - When it runs smooth and you think it can run slower, decrease the value.</p>
 
     <p>GLoad Limits allows the user to set which limits will show on the G Meter on the GPS/AHRS page.
         Enter a space-separated list of G limits, e.g. "-1.76 4.4".</p>


### PR DESCRIPTION
I noticed that my fan never really did run nice and often way to fast:

With this pull request I like to add PID control to the fan to keep the CPU at a specific temperature, currently set to 50 degrees.

To allow users to set a low PWM value for the fan the controller will give the fan a little kick at 100% for 500ms to let the fan start runningwhen it came from 0 to some specific value. Thereafter PWM control will be controlled between PWMDutyMin and 100%.

Most important changes:

Removed the need for the deprecated wiringpi
Add's PID control to the fan
Add's PWM (0..100) value to prometheus
Set a lower PWM control frequency to reduce PWM noise.
Add's a bit of help text on how to tune on the stratux web page.
change the number of px for the help text on the right side so it shows up better.
This was tested with a 5000rpm 4010 fan. I am very curious how this will run with other fans on other people before considering merging to master soo help is wanted for some tests.