### PR TITLE
add ! to valid SSID string regex

### DIFF
--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -672,7 +672,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 	}
 }
 
-function isValidSSID(str) { return /^[a-zA-Z0-9() \._-]{1,32}$/g.test(str); }
+function isValidSSID(str) { return /^[a-zA-Z0-9()! \._-]{1,32}$/g.test(str); }
 function isValidWPA(str) { return /^[\u0020-\u007e]{8,63}$/g.test(str); }
 function isValidPin(str) { return /^([\d]{4}|[\d]{8})$/g.test(str); }
 


### PR DESCRIPTION
Added the exclamation mark (!) to the regex for valid SSID strings, my (manufacturer set) SSID had an exclamation mark and it's easier to fix this than change all other devices wifi login credentials 