### PR TITLE
UART config bug fixed

### DIFF
--- a/main/gps.go
+++ b/main/gps.go
@@ -293,7 +293,8 @@ func initGPSSerial() bool {
 			log.Printf("Finished writing SiRF GPS config to %s. Opening port to test connection.\n", device)
 		}
 	} else if globalStatus.GPS_detected_type == GPS_TYPE_UBX6 || globalStatus.GPS_detected_type == GPS_TYPE_UBX7 ||
-	          globalStatus.GPS_detected_type == GPS_TYPE_UBX8 || globalStatus.GPS_detected_type == GPS_TYPE_UBX9 {
+	          globalStatus.GPS_detected_type == GPS_TYPE_UBX8 || globalStatus.GPS_detected_type == GPS_TYPE_UBX9 ||
+		  globalStatus.GPS_detected_type == GPS_TYPE_UART {
 
 		// Byte order for UBX configuration is little endian.
 


### PR DESCRIPTION
u-blox config was not sent when GPS connected via UART. As line 320 suggests, all GPS connected to UART will be treated as u-blox 8.