### PR TITLE
bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 
 
 
-all: libdump978.so xdump1090 xrtlais gen_gdl90 $(PLATFORMDEPENDENT)
+all: libdump978.so xdump1090 xrtlais gen_gdl90 librtlsdr $(PLATFORMDEPENDENT)
 
 gen_gdl90: main/*.go common/*.go libdump978.so
 	LIBRARY_PATH=$(CURDIR) CGO_CFLAGS_ALLOW="-L$(CURDIR)" go build $(BUILDINFO) -o gen_gdl90 -p 4 ./main/
@@ -42,6 +42,9 @@ libdump978.so: dump978/*.c dump978/*.h
 xrtlais:
 	git submodule update --init rtl-ais
 	cd rtl-ais && sed -i 's/^LDFLAGS+=-lpthread.*/LDFLAGS+=-lpthread -lm -lrtlsdr -L \/usr\/lib\//' Makefile && make
+
+librtlsdr:
+	sudo apt install librtlsdr-dev
 
 
 .PHONY: test


### PR DESCRIPTION
fix for this bug 
No package 'librtlsdr' found
Package libusb-1.0 was not found in the pkg-config search path. Perhaps you should add the directory containing `libusb-1.0.pc' to the PKG_CONFIG_PATH environment variable
No package 'libusb-1.0' found
cc -c rtl_ais.c -o rtl_ais.o -O2 -g -Wall -W  -I./aisdecoder -I ./aisdecoder/lib -I./tcp_listener  rtl_ais.c:42:10: fatal error: rtl-sdr.h: No such file or directory
   42 | #include <rtl-sdr.h>
      |          ^~~~~~~~~~~
compilation terminated.