### PR TITLE
bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,13 @@ endif
 
 
 
-all: libdump978.so xdump1090 xrtlais gen_gdl90 $(PLATFORMDEPENDENT)
+all: libncurses librtlsdr libdump978.so xdump1090 xrtlais gen_gdl90 $(PLATFORMDEPENDENT)
+
+libncurses:
+	sudo apt-get install libncurses-dev
+
+librtlsdr:
+	sudo apt install librtlsdr-dev
 
 gen_gdl90: main/*.go common/*.go libdump978.so
 	LIBRARY_PATH=$(CURDIR) CGO_CFLAGS_ALLOW="-L$(CURDIR)" go build $(BUILDINFO) -o gen_gdl90 -p 4 ./main/


### PR DESCRIPTION
cc -c rtl_ais.c -o rtl_ais.o -O2 -g -Wall -W -I./aisdecoder -I ./aisdecoder/lib -I./tcp_listener rtl_ais.c:42:10: fatal error: rtl-sdr.h: No such file or directory 42 | #include <rtl-sdr.h>
| ^~~~~~~~~~~
compilation terminated.

O3 -g -std=c11 -fno-common -Wall -Wmissing-declarations -Werror -W -c interactive.c -o interactive.o interactive.c:52:10: fatal error: curses.h: No such file or directory 52 | #include <curses.h>
| ^~~~~~~~~~
compilation terminated.