### PR TITLE
Feature/fix wifi

### DIFF
--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -349,9 +349,6 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 		// Update theme
 		$scope.$parent.updateTheme($scope.DarkMode);
-
-
-		$scope.CountryCodeList = countryCodes;
 	}
 
 	function getSettings() {

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -609,7 +609,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 		if (($scope.WiFiSSID === undefined) || ($scope.WiFiSSID === null) || !isValidSSID($scope.WiFiSSID)) {
 				$scope.WiFiErrors.WiFiSSID = "Your Network Name(\"SSID\") must be at least 1 character " +
-					"but not more than 32 characters. It can only contain a-z, A-Z, 0-9, _ or -.";
+					"but not more than 32 characters. It can only contain a-z, A-Z, 0-9, _ or '-.";
 				$scope.WiFiErrors.Errors = true;
 			}
 
@@ -689,7 +689,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 	}
 }
 
-function isValidSSID(str) { return /^[a-zA-Z0-9()! \._-]{1,32}$/g.test(str); }
+function isValidSSID(str) { return /^[a-zA-Z0-9()! \._'-]{1,32}$/g.test(str); }
 function isValidWPA(str) { return /^[\u0020-\u007e]{8,63}$/g.test(str); }
 function isValidPin(str) { return /^([\d]{4}|[\d]{8})$/g.test(str); }
 


### PR DESCRIPTION
Hello,

It seems that in 8cd2a3d6ec8810c6dc19f0403e0efd0a1d5cd16a a bug was introduced to the settings page. An unused variable `CountryCodeList` was added, but wrongly assigned (correct assignment would have been `$scope.countryCodes`). This causes an error in the console, but probably didn't bother anyone so far, so it went unnoticed. I just removed the variable and it seems to work now without any errors.

Also, I have found out that `'` is not allowed in SSID names. This is quite common for iPhones though, so I added that and was able to connect to an iPhone hotspot. Officially, SSID is not even restricted to any characters (according to last standard 802.11-2012 Section 6.3.11.2.2, it can be 0-32 octets with an unspecified or UTF-8 encoding), but I thought you wouldn't like this, so I just added an apostrophe. I hope that's ok.

P.S. It occurred to me that Stratux only connects to iPhone hotspot if "compatibility mode" is turned on the phone, whatever that is. I don't know whether this is a known issue...