### PR TITLE
Bug Fixes

### DIFF
--- a/image/mk_europe_edition64.sh
+++ b/image/mk_europe_edition64.sh
@@ -11,7 +11,7 @@ ZIPNAME="2024-03-15-raspios-bookworm-arm64-lite.img.xz"
 IMGNAME="$(basename $ZIPNAME .xz)"
 TMPDIR="$HOME/stratux-tmp"
 # REMOTE_ORIGIN=$(git config --get remote.origin.url) # would be nicer, but doesn't work with ssh clone..
-REMOTE_ORIGIN="https://github.com/b3nn0/stratux.git"
+REMOTE_ORIGIN="https://github.com/JonWilder/stratux.git"
 
 die() {
     echo $1
@@ -73,9 +73,13 @@ cd ../../
 
 # Use latest qemu-aarch64-static version, since aarch64 doesn't seem to be that stable yet..
 if [ "$(arch)" != "aarch64" ]; then
-    wget -P mnt/usr/bin/ https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-aarch64-static
-    chmod +x mnt/usr/bin/qemu-aarch64-static
-    unshare -mpfu chroot mnt qemu-aarch64-static -cpu cortex-a72 /bin/bash -c /root/stratux/image/mk_europe_edition_device_setup64.sh
+    #wget -P mnt/usr/bin/ https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-aarch64-static
+    #chmod +x mnt/usr/bin/qemu-aarch64-static
+    #unshare -mpfu chroot mnt qemu-aarch64-static -cpu cortex-a72 /bin/bash -c /root/stratux/image/mk_europe_edition_device_setup64.sh
+    # For use on Gentoo systems with Qemu
+    cp /usr/bin/qemu-aarch64 mnt/usr/bin
+    chmod +x mnt/usr/bin/qemu-aarch64
+    unshare -mpfu chroot mnt qemu-aarch64 /bin/bash -c /root/stratux/image/mk_europe_edition_device_setup64.sh
 else
     unshare -mpfu chroot mnt /bin/bash -c /root/stratux/image/mk_europe_edition_device_setup64.sh
 fi

--- a/image/mk_europe_edition64.sh
+++ b/image/mk_europe_edition64.sh
@@ -6,8 +6,8 @@
 # Run this script as root.
 # Run with argument "dev" to not clone the stratux repository from remote, but instead copy this current local checkout onto the image
 set -x
-BASE_IMAGE_URL="https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2024-03-15/2024-03-15-raspios-bookworm-arm64-lite.img.xz"
-ZIPNAME="2024-03-15-raspios-bookworm-arm64-lite.img.xz"
+BASE_IMAGE_URL="https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2024-07-04/2024-07-04-raspios-bookworm-arm64-lite.img.xz"
+ZIPNAME="2024-07-04-raspios-bookworm-arm64-lite.img.xz"
 IMGNAME="$(basename $ZIPNAME .xz)"
 TMPDIR="$HOME/stratux-tmp"
 # REMOTE_ORIGIN=$(git config --get remote.origin.url) # would be nicer, but doesn't work with ssh clone..

--- a/image/mk_europe_edition_device_setup64.sh
+++ b/image/mk_europe_edition_device_setup64.sh
@@ -39,7 +39,6 @@ cd bluez-5.76
 cd ..
 rm -r bluez-5.76
 PATH=/root/fake:$PATH RUNLEVEL=1 apt autoremove --purge --yes libusb-dev libdbus-1-dev libglib2.0-dev libudev-dev libical-dev libreadline-dev python3-pygments
-systemctl daemon-reload
 systemctl enable bluetooth
 
 # try to reduce writing to SD card as much as possible, so they don't get bricked when yanking the power cable

--- a/image/mk_europe_edition_device_setup64.sh
+++ b/image/mk_europe_edition_device_setup64.sh
@@ -92,7 +92,7 @@ make -j1
 make install
 cd /root/
 rm -r rtl-sdr
-
+PATH=/root/fake:/usr/sbin:$PATH
 ldconfig
 
 #kalibrate-rtl


### PR DESCRIPTION
Hi.

Recent changes to the master branch -

Updated image to the latest Pi OS image (2024-07-04)
Removed a call to systemctl daemon-reload, which, on a chrooted system, was causing an error that made the child script terminate prematurely.
Added /usr/sbin to PATH prior to the call to ldconfig at the end of the build of rtl-sdr package. This directory may already be part of existing PATH on your host system, but it isn't on my Gentoo system.

I also commented out the starting of Qemu and left in how I had to do it on a Gentoo system. May want to try it on your distro and see if it works on other distros. For whatever reason, the Qemu package on the Portage tree only likes its own aarch64 container.

Regards,

Jonathan Wilder