### PR TITLE
Correctly process multiple NMEA messages on 1 line

### DIFF
--- a/main/gps.go
+++ b/main/gps.go
@@ -1954,15 +1954,19 @@ func gpsSerialReader() {
 		}
 
 		s := scanner.Text()
-		startIdx := strings.Index(s, "$")
-		if startIdx < 0 {
-			continue
-		}
-		s = s[startIdx:]
-
-		if !processNMEALine(s) {
-			if globalSettings.DEBUG {
-				fmt.Printf("processNMEALine() exited early -- %s\n", s)
+		// Split the line into individual NMEA messages
+		messages := strings.Split(s, "$")
+		for _, msg := range messages {
+			if len(msg) == 0 {
+				continue
+			}
+			// Add back the $ prefix that was removed by Split
+			msg = "$" + msg
+			
+			if !processNMEALine(msg) {
+				if globalSettings.DEBUG {
+					fmt.Printf("processNMEALine() exited early -- %s\n", msg)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I connected [Garmin GLO 2](https://www.garmin.com/en-US/p/645104) over bluetooth to a Raspberry Pi running Stratux. Connection is done manually for now using `bluetoothctl` and `rfcomm bind` (I plan to automate that later).

However, the problem is that Garmin apparently reports multiple NMEA messages on a single line, e.g.:
```
$GPRMC,155718.7,V,1234.567890,N,01$GPRMC,155718.8,V,1234.567890,N,01234.567890,E,,,201024,005.6,E,N*17
```

That caused stratux to fail parsing on [this line](https://github.com/stratux/stratux/blob/master/main/gps.go#L1127).

Proposing a fix to support multiple messages on a single line. Tested on my device, works fine.