### PR TITLE
Support mixed content SSL & non-SSL on web interface to enable revers…

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -6,6 +6,7 @@
 	<title>Stratux</title>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 	<meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimal-ui" />
+        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 	<!-- android -->
 	<meta name="mobile-web-app-capable" content="yes">
 	<link href="img/logo-android3.png" rel="icon" />


### PR DESCRIPTION
Use case: static Stratux setup powering an instance of Stratux available behind a reverse proxy, for use in monitoring local traffic.

Issue: when using common reverse proxy setup (such as Cloudflare Zero Trust), javascript modules use a "ws://" format for web sockets, which is not re-written to "wss://", triggering a mixed content issue on most browsers and causing the page to show an error.

Solution: while there are likely ways for the jscript to issue the correct ws:// or wss:// it's easier to add a single meta directive to the page header. Since this page is usually served over http:// there are no additional security risks adding this, and it easily and quickly solves the issue.