### PR TITLE
Fix SoftRF config readback and MB protocol mapping

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1244,6 +1244,15 @@ type settings struct {
 	OGNReg               string
 	OGNTxPower           int
 
+	// SoftRF-specific settings (only used when GPS_TYPE_SOFTRF is active)
+	SoftRFProtocol    int  // 0=Legacy, 1=OGNTP, 5=FANET, 6=Latest, 8=ADS-L
+	SoftRFAltProtocol int  // -1=none, or a valid secondary protocol value
+	SoftRFBand        int  // 1=EU 868MHz, 2=US 915MHz, 3=AU 921MHz, 4=NZ 869MHz, 5=RU 868MHz, 7=UK 869MHz
+	SoftRFAlarm       int  // 0=none, 1=distance, 2=vector, 3=legacy
+	SoftRFRelay       int  // 0=off, 1=when landed, 2=all, 3=relay-only
+	SoftRFStealth     bool
+	SoftRFNoTrack     bool
+
 	PWMDutyMin           int
 
 	// manual GPS config  (versus autodetect)

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1245,11 +1245,11 @@ type settings struct {
 	OGNTxPower           int
 
 	// SoftRF-specific settings (only used when GPS_TYPE_SOFTRF is active)
-	SoftRFProtocol    int  // 0=Legacy, 1=OGNTP, 5=FANET, 6=Latest, 8=ADS-L
-	SoftRFAltProtocol int  // -1=none, or a valid secondary protocol value
-	SoftRFBand        int  // 1=EU 868MHz, 2=US 915MHz, 3=AU 921MHz, 4=NZ 869MHz, 5=RU 868MHz, 7=UK 869MHz
-	SoftRFAlarm       int  // 0=none, 1=distance, 2=vector, 3=legacy
-	SoftRFRelay       int  // 0=off, 1=when landed, 2=all, 3=relay-only
+	SoftRFProtocol    int  // -1=unknown, 0=Legacy, 1=OGNTP, 5=FANET, 6=Latest, 8=ADS-L
+	SoftRFAltProtocol int  // -2=unknown, -1=none, or a valid secondary protocol value
+	SoftRFBand        int  // -1=unknown, 1=EU 868MHz, 2=US 915MHz, 3=AU 921MHz, 4=NZ 869MHz, 5=RU 868MHz, 7=UK 869MHz
+	SoftRFAlarm       int  // -1=unknown, 0=none, 1=distance, 2=vector, 3=legacy
+	SoftRFRelay       int  // -1=unknown, 0=off, 1=when landed, 2=all, 3=relay-only
 	SoftRFStealth     bool
 	SoftRFNoTrack     bool
 
@@ -1344,6 +1344,11 @@ func defaultSettings() {
 	globalSettings.GPS_Enabled = true
 	globalSettings.IMU_Sensor_Enabled = true
 	globalSettings.BMP_Sensor_Enabled = true
+	globalSettings.SoftRFProtocol = -1
+	globalSettings.SoftRFAltProtocol = -2
+	globalSettings.SoftRFBand = -1
+	globalSettings.SoftRFAlarm = -1
+	globalSettings.SoftRFRelay = -1
 	//FIXME: Need to change format below.
 	globalSettings.NetworkOutputs = []networkConnection{
 		{Conn: nil, Ip: "", Port: 4000, Capability: NETWORK_GDL90_STANDARD | NETWORK_AHRS_GDL90},
@@ -1895,4 +1900,3 @@ func main() {
 		select {}
 	}
 }
-

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -581,15 +581,30 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 					case "OGNTxPower":
 						globalSettings.OGNTxPower = int(val.(float64))
 					case "SoftRFProtocol":
-						globalSettings.SoftRFProtocol = int(val.(float64))
+						v := int(val.(float64))
+						if v >= 0 {
+							globalSettings.SoftRFProtocol = v
+						}
 					case "SoftRFAltProtocol":
-						globalSettings.SoftRFAltProtocol = int(val.(float64))
+						v := int(val.(float64))
+						if v >= -1 {
+							globalSettings.SoftRFAltProtocol = v
+						}
 					case "SoftRFBand":
-						globalSettings.SoftRFBand = int(val.(float64))
+						v := int(val.(float64))
+						if v > 0 {
+							globalSettings.SoftRFBand = v
+						}
 					case "SoftRFAlarm":
-						globalSettings.SoftRFAlarm = int(val.(float64))
+						v := int(val.(float64))
+						if v >= 0 {
+							globalSettings.SoftRFAlarm = v
+						}
 					case "SoftRFRelay":
-						globalSettings.SoftRFRelay = int(val.(float64))
+						v := int(val.(float64))
+						if v >= 0 {
+							globalSettings.SoftRFRelay = v
+						}
 					case "SoftRFStealth":
 						globalSettings.SoftRFStealth = val.(bool)
 					case "SoftRFNoTrack":

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -580,6 +580,20 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 						reconfigureTracker = true
 					case "OGNTxPower":
 						globalSettings.OGNTxPower = int(val.(float64))
+					case "SoftRFProtocol":
+						globalSettings.SoftRFProtocol = int(val.(float64))
+					case "SoftRFAltProtocol":
+						globalSettings.SoftRFAltProtocol = int(val.(float64))
+					case "SoftRFBand":
+						globalSettings.SoftRFBand = int(val.(float64))
+					case "SoftRFAlarm":
+						globalSettings.SoftRFAlarm = int(val.(float64))
+					case "SoftRFRelay":
+						globalSettings.SoftRFRelay = int(val.(float64))
+					case "SoftRFStealth":
+						globalSettings.SoftRFStealth = val.(bool)
+					case "SoftRFNoTrack":
+						globalSettings.SoftRFNoTrack = val.(bool)
 						reconfigureTracker = true
 					case "PWMDutyMin":
 						globalSettings.PWMDutyMin = int(val.(float64))

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -361,8 +361,8 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 			globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
 		} else if key == "altprotocol" {
 			v, _ := strconv.Atoi(value)
-			if v == 0 {
-				globalSettings.SoftRFAltProtocol = -1 // 0 means "none" in SoftRF
+			if v == 0 || v == 255 {
+				globalSettings.SoftRFAltProtocol = -1 // 0/255 mean "none" in SoftRF
 			} else {
 				globalSettings.SoftRFAltProtocol = v
 			}
@@ -420,8 +420,8 @@ func (tracker *SoftRF) writeInitialConfig(serialPort *serial.Port) bool {
 		serialPort.Write([]byte(msg))
 		changed = true
 	}
-	// Auto-set band from Stratux region if not already user-configured
-	if globalSettings.SoftRFBand == 0 {
+	deviceBand, haveDeviceBand := tracker.settings["band"]
+	if globalSettings.SoftRFBand <= 0 && haveDeviceBand && deviceBand == "0" {
 		switch globalSettings.RegionSelected {
 		case 1: // US
 			globalSettings.SoftRFBand = 2 // 915 MHz
@@ -432,7 +432,7 @@ func (tracker *SoftRF) writeInitialConfig(serialPort *serial.Port) bool {
 		}
 		log.Printf("SoftRF: auto-set band to %d from RegionSelected=%d", globalSettings.SoftRFBand, globalSettings.RegionSelected)
 	}
-	if s, ok := tracker.settings["band"]; !ok || strconv.Itoa(globalSettings.SoftRFBand) != s {
+	if globalSettings.SoftRFBand > 0 && (!haveDeviceBand || strconv.Itoa(globalSettings.SoftRFBand) != deviceBand) {
 		msg := appendNmeaChecksum("$PSRFS,0,band," + strconv.Itoa(globalSettings.SoftRFBand)) + "\r\n"
 		log.Printf("Configure SoftRF band: %s", msg)
 		serialPort.Write([]byte(msg))
@@ -482,32 +482,46 @@ func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
 	}
 
 	// RF protocol
-	proto := strconv.Itoa(globalSettings.SoftRFProtocol)
-	if s, ok := tracker.settings["protocol"]; !ok || proto != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,protocol," + proto) + "\r\n")
+	if globalSettings.SoftRFProtocol >= 0 {
+		proto := strconv.Itoa(globalSettings.SoftRFProtocol)
+		if s, ok := tracker.settings["protocol"]; !ok || proto != s {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,protocol," + proto) + "\r\n")
+		}
 	}
-	altProto := "0"
-	if globalSettings.SoftRFAltProtocol >= 0 {
-		altProto = strconv.Itoa(globalSettings.SoftRFAltProtocol)
-	}
-	if s, ok := tracker.settings["altprotocol"]; !ok || altProto != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,altprotocol," + altProto) + "\r\n")
+	if globalSettings.SoftRFAltProtocol >= -1 {
+		altProto := "0"
+		if globalSettings.SoftRFAltProtocol >= 0 {
+			altProto = strconv.Itoa(globalSettings.SoftRFAltProtocol)
+		}
+		currentAltProto := tracker.settings["altprotocol"]
+		if currentAltProto == "255" {
+			currentAltProto = "0"
+		}
+		if currentAltProto != altProto {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,altprotocol," + altProto) + "\r\n")
+		}
 	}
 
 	// Band
-	band := strconv.Itoa(globalSettings.SoftRFBand)
-	if s, ok := tracker.settings["band"]; !ok || band != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,band," + band) + "\r\n")
+	if globalSettings.SoftRFBand > 0 {
+		band := strconv.Itoa(globalSettings.SoftRFBand)
+		if s, ok := tracker.settings["band"]; !ok || band != s {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,band," + band) + "\r\n")
+		}
 	}
 
 	// Alarm, relay, stealth, no_track
-	alarm := strconv.Itoa(globalSettings.SoftRFAlarm)
-	if s, ok := tracker.settings["alarm"]; !ok || alarm != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,alarm," + alarm) + "\r\n")
+	if globalSettings.SoftRFAlarm >= 0 {
+		alarm := strconv.Itoa(globalSettings.SoftRFAlarm)
+		if s, ok := tracker.settings["alarm"]; !ok || alarm != s {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,alarm," + alarm) + "\r\n")
+		}
 	}
-	relay := strconv.Itoa(globalSettings.SoftRFRelay)
-	if s, ok := tracker.settings["relay"]; !ok || relay != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,relay," + relay) + "\r\n")
+	if globalSettings.SoftRFRelay >= 0 {
+		relay := strconv.Itoa(globalSettings.SoftRFRelay)
+		if s, ok := tracker.settings["relay"]; !ok || relay != s {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,relay," + relay) + "\r\n")
+		}
 	}
 	stealth := "0"
 	if globalSettings.SoftRFStealth {
@@ -535,7 +549,6 @@ func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
 	
 	return len(messages) > 0
 }
-
 
 
 

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -357,6 +357,25 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 			globalSettings.OGNAddrType, _ = strconv.Atoi(value)
 		} else if key == "aircraft_id" {
 			globalSettings.OGNAddr = value
+		} else if key == "protocol" {
+			globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
+		} else if key == "altprotocol" {
+			v, _ := strconv.Atoi(value)
+			if v == 0 {
+				globalSettings.SoftRFAltProtocol = -1 // 0 means "none" in SoftRF
+			} else {
+				globalSettings.SoftRFAltProtocol = v
+			}
+		} else if key == "band" {
+			globalSettings.SoftRFBand, _ = strconv.Atoi(value)
+		} else if key == "alarm" {
+			globalSettings.SoftRFAlarm, _ = strconv.Atoi(value)
+		} else if key == "relay" {
+			globalSettings.SoftRFRelay, _ = strconv.Atoi(value)
+		} else if key == "stealth" {
+			globalSettings.SoftRFStealth = value == "1"
+		} else if key == "no_track" {
+			globalSettings.SoftRFNoTrack = value == "1"
 		}
 		return true
 	}
@@ -401,6 +420,25 @@ func (tracker *SoftRF) writeInitialConfig(serialPort *serial.Port) bool {
 		serialPort.Write([]byte(msg))
 		changed = true
 	}
+	// Auto-set band from Stratux region if not already user-configured
+	if globalSettings.SoftRFBand == 0 {
+		switch globalSettings.RegionSelected {
+		case 1: // US
+			globalSettings.SoftRFBand = 2 // 915 MHz
+		case 2: // EU
+			globalSettings.SoftRFBand = 1 // 868 MHz
+		default:
+			globalSettings.SoftRFBand = 1 // default EU
+		}
+		log.Printf("SoftRF: auto-set band to %d from RegionSelected=%d", globalSettings.SoftRFBand, globalSettings.RegionSelected)
+	}
+	if s, ok := tracker.settings["band"]; !ok || strconv.Itoa(globalSettings.SoftRFBand) != s {
+		msg := appendNmeaChecksum("$PSRFS,0,band," + strconv.Itoa(globalSettings.SoftRFBand)) + "\r\n"
+		log.Printf("Configure SoftRF band: %s", msg)
+		serialPort.Write([]byte(msg))
+		changed = true
+	}
+
 	if changed {
 		serialPort.Write([]byte(appendNmeaChecksum("$PSRFC,SAV") + "\r\n"))
 	}
@@ -413,6 +451,13 @@ func (tracker *SoftRF) requestTrackerConfig(serialPort *serial.Port) {
 	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,acft_type,?") + "\r\n"))
 	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,aircraft_id,?") + "\r\n"))
 	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,id_method,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,protocol,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,altprotocol,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,band,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,alarm,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,relay,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,stealth,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,no_track,?") + "\r\n"))
 }
 
 func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
@@ -434,6 +479,49 @@ func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
 	}
 	if s, ok := tracker.settings["aircraft_id"]; !ok || addr != s {
 		messages = append(messages, appendNmeaChecksum("$PSRFS,0,aircraft_id," + addr) + "\r\n")
+	}
+
+	// RF protocol
+	proto := strconv.Itoa(globalSettings.SoftRFProtocol)
+	if s, ok := tracker.settings["protocol"]; !ok || proto != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,protocol," + proto) + "\r\n")
+	}
+	altProto := "0"
+	if globalSettings.SoftRFAltProtocol >= 0 {
+		altProto = strconv.Itoa(globalSettings.SoftRFAltProtocol)
+	}
+	if s, ok := tracker.settings["altprotocol"]; !ok || altProto != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,altprotocol," + altProto) + "\r\n")
+	}
+
+	// Band
+	band := strconv.Itoa(globalSettings.SoftRFBand)
+	if s, ok := tracker.settings["band"]; !ok || band != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,band," + band) + "\r\n")
+	}
+
+	// Alarm, relay, stealth, no_track
+	alarm := strconv.Itoa(globalSettings.SoftRFAlarm)
+	if s, ok := tracker.settings["alarm"]; !ok || alarm != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,alarm," + alarm) + "\r\n")
+	}
+	relay := strconv.Itoa(globalSettings.SoftRFRelay)
+	if s, ok := tracker.settings["relay"]; !ok || relay != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,relay," + relay) + "\r\n")
+	}
+	stealth := "0"
+	if globalSettings.SoftRFStealth {
+		stealth = "1"
+	}
+	if s, ok := tracker.settings["stealth"]; !ok || stealth != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,stealth," + stealth) + "\r\n")
+	}
+	noTrack := "0"
+	if globalSettings.SoftRFNoTrack {
+		noTrack = "1"
+	}
+	if s, ok := tracker.settings["no_track"]; !ok || noTrack != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,no_track," + noTrack) + "\r\n")
 	}
 
 	for _, msg := range messages {

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -333,6 +333,54 @@ func (tracker *SoftRF) initNewConnection(serialPort *serial.Port) {
 	tracker.settings = make(map[string]string)
 }
 
+func softRFProtocolSettingFromWire(v int) int {
+	switch v {
+	case 0, 6:
+		return 0 // Legacy
+	case 7:
+		return 6 // Latest
+	default:
+		return v
+	}
+}
+
+func softRFProtocolWireFromSetting(v int) int {
+	switch v {
+	case 0:
+		return 6 // Legacy
+	case 6:
+		return 7 // Latest
+	default:
+		return v
+	}
+}
+
+func softRFAltProtocolSettingFromWire(v int) int {
+	switch v {
+	case 0, 255:
+		return -1 // None
+	case 6:
+		return 0 // Legacy
+	case 7:
+		return 6 // Latest
+	default:
+		return v
+	}
+}
+
+func softRFAltProtocolWireFromSetting(v int) int {
+	switch v {
+	case -1:
+		return 0 // None
+	case 0:
+		return 6 // Legacy
+	case 6:
+		return 7 // Latest
+	default:
+		return v
+	}
+}
+
 
 func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 	if nmea[0] == "PSRFH" {
@@ -358,14 +406,11 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 		} else if key == "aircraft_id" {
 			globalSettings.OGNAddr = value
 		} else if key == "protocol" {
-			globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
+			v, _ := strconv.Atoi(value)
+			globalSettings.SoftRFProtocol = softRFProtocolSettingFromWire(v)
 		} else if key == "altprotocol" {
 			v, _ := strconv.Atoi(value)
-			if v == 0 || v == 255 {
-				globalSettings.SoftRFAltProtocol = -1 // 0/255 mean "none" in SoftRF
-			} else {
-				globalSettings.SoftRFAltProtocol = v
-			}
+			globalSettings.SoftRFAltProtocol = softRFAltProtocolSettingFromWire(v)
 		} else if key == "band" {
 			globalSettings.SoftRFBand, _ = strconv.Atoi(value)
 		} else if key == "alarm" {
@@ -483,16 +528,13 @@ func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
 
 	// RF protocol
 	if globalSettings.SoftRFProtocol >= 0 {
-		proto := strconv.Itoa(globalSettings.SoftRFProtocol)
+		proto := strconv.Itoa(softRFProtocolWireFromSetting(globalSettings.SoftRFProtocol))
 		if s, ok := tracker.settings["protocol"]; !ok || proto != s {
 			messages = append(messages, appendNmeaChecksum("$PSRFS,0,protocol," + proto) + "\r\n")
 		}
 	}
 	if globalSettings.SoftRFAltProtocol >= -1 {
-		altProto := "0"
-		if globalSettings.SoftRFAltProtocol >= 0 {
-			altProto = strconv.Itoa(globalSettings.SoftRFAltProtocol)
-		}
+		altProto := strconv.Itoa(softRFAltProtocolWireFromSetting(globalSettings.SoftRFAltProtocol))
 		currentAltProto := tracker.settings["altprotocol"]
 		if currentAltProto == "255" {
 			currentAltProto = "0"
@@ -549,8 +591,6 @@ func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
 	
 	return len(messages) > 0
 }
-
-
 
 
 

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -344,14 +344,15 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.OGNTxPower = settings.OGNTxPower;
 
 		// SoftRF-specific settings
-		$scope.SoftRFProtocol = (settings.SoftRFProtocol || 0).toString();
-		$scope.SoftRFAltProtocol = (settings.SoftRFAltProtocol !== undefined ? settings.SoftRFAltProtocol : -1).toString();
-		$scope.SoftRFBand = (settings.SoftRFBand || 1).toString();
-		$scope.SoftRFAlarm = (settings.SoftRFAlarm || 0).toString();
-		$scope.SoftRFRelay = (settings.SoftRFRelay || 0).toString();
+		$scope.SoftRFProtocol = (settings.SoftRFProtocol !== undefined ? settings.SoftRFProtocol : -1).toString();
+		$scope.SoftRFAltProtocol = (settings.SoftRFAltProtocol !== undefined ? settings.SoftRFAltProtocol : -2).toString();
+		$scope.SoftRFBand = (settings.SoftRFBand !== undefined ? settings.SoftRFBand : -1).toString();
+		$scope.SoftRFAlarm = (settings.SoftRFAlarm !== undefined ? settings.SoftRFAlarm : -1).toString();
+		$scope.SoftRFRelay = (settings.SoftRFRelay !== undefined ? settings.SoftRFRelay : -1).toString();
 		$scope.SoftRFStealth = settings.SoftRFStealth || false;
 		$scope.SoftRFNoTrack = settings.SoftRFNoTrack || false;
 		$scope.softRFCompatSecondary = [];
+		$scope.softRFConfigReady = false;
 		$scope.updateSoftRFCompatProtocols();
 
 		$scope.PWMDutyMin = settings.PWMDutyMin;
@@ -731,9 +732,14 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 	};
 	$scope.updateSoftRFCompatProtocols = function() {
 		var primary = $scope.SoftRFProtocol;
+		$scope.softRFConfigReady = primary !== "-1" && $scope.SoftRFAltProtocol !== "-2" && $scope.SoftRFBand !== "-1" && $scope.SoftRFAlarm !== "-1" && $scope.SoftRFRelay !== "-1";
+		if (!$scope.softRFConfigReady) {
+			$scope.softRFCompatSecondary = [];
+			return;
+		}
 		$scope.softRFCompatSecondary = softRFCompatMap[primary] || [];
 		// Reset alt protocol if no longer compatible
-		var stillValid = $scope.softRFCompatSecondary.some(function(p) {
+		var stillValid = $scope.SoftRFAltProtocol === "-1" || $scope.softRFCompatSecondary.some(function(p) {
 			return p.value === $scope.SoftRFAltProtocol;
 		});
 		if (!stillValid) { $scope.SoftRFAltProtocol = "-1"; }

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -343,6 +343,17 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.OGNReg = settings.OGNReg;
 		$scope.OGNTxPower = settings.OGNTxPower;
 
+		// SoftRF-specific settings
+		$scope.SoftRFProtocol = (settings.SoftRFProtocol || 0).toString();
+		$scope.SoftRFAltProtocol = (settings.SoftRFAltProtocol !== undefined ? settings.SoftRFAltProtocol : -1).toString();
+		$scope.SoftRFBand = (settings.SoftRFBand || 1).toString();
+		$scope.SoftRFAlarm = (settings.SoftRFAlarm || 0).toString();
+		$scope.SoftRFRelay = (settings.SoftRFRelay || 0).toString();
+		$scope.SoftRFStealth = settings.SoftRFStealth || false;
+		$scope.SoftRFNoTrack = settings.SoftRFNoTrack || false;
+		$scope.softRFCompatSecondary = [];
+		$scope.updateSoftRFCompatProtocols();
+
 		$scope.PWMDutyMin = settings.PWMDutyMin;
 
 		// Update theme
@@ -710,6 +721,24 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		return "???";
 	}
 
+	// SoftRF protocol compatibility map: primary -> valid secondaries
+	var softRFCompatMap = {
+		"0": [{value:"6",label:"Latest (FLARM v7)"},{value:"8",label:"ADS-L"}],
+		"1": [{value:"6",label:"Latest (FLARM v7)"}],
+		"6": [{value:"0",label:"Legacy (FLARM)"},{value:"1",label:"OGNTP"},{value:"8",label:"ADS-L"}],
+		"8": [{value:"6",label:"Latest (FLARM v7)"}],
+		"5": []
+	};
+	$scope.updateSoftRFCompatProtocols = function() {
+		var primary = $scope.SoftRFProtocol;
+		$scope.softRFCompatSecondary = softRFCompatMap[primary] || [];
+		// Reset alt protocol if no longer compatible
+		var stillValid = $scope.softRFCompatSecondary.some(function(p) {
+			return p.value === $scope.SoftRFAltProtocol;
+		});
+		if (!stillValid) { $scope.SoftRFAltProtocol = "-1"; }
+	};
+
 	$scope.updateOgnTrackerConfig = function(action) {
 		var newsettings = {
 			"OGNAddrType": parseInt($scope.OGNAddrType),
@@ -717,7 +746,14 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			"OGNAcftType": parseInt($scope.OGNAcftType),
 			"OGNPilot": $scope.OGNPilot,
 			"OGNReg": $scope.OGNReg,
-			"OGNTxPower": $scope.OGNTxPower
+			"OGNTxPower": $scope.OGNTxPower,
+			"SoftRFProtocol": parseInt($scope.SoftRFProtocol),
+			"SoftRFAltProtocol": parseInt($scope.SoftRFAltProtocol),
+			"SoftRFBand": parseInt($scope.SoftRFBand),
+			"SoftRFAlarm": parseInt($scope.SoftRFAlarm),
+			"SoftRFRelay": parseInt($scope.SoftRFRelay),
+			"SoftRFStealth": $scope.SoftRFStealth,
+			"SoftRFNoTrack": $scope.SoftRFNoTrack
 		};
 		setSettings(angular.toJson(newsettings));
 

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -724,11 +724,12 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 	// SoftRF protocol compatibility map: primary -> valid secondaries
 	var softRFCompatMap = {
-		"0": [{value:"6",label:"Latest (FLARM v7)"},{value:"8",label:"ADS-L"}],
-		"1": [{value:"6",label:"Latest (FLARM v7)"}],
+		"0": [{value:"6",label:"Latest (FLARM v7)"}],
+		"1": [{value:"6",label:"Latest (FLARM v7)"},{value:"8",label:"ADS-L"}],
+		"2": [],
+		"5": [],
 		"6": [{value:"0",label:"Legacy (FLARM)"},{value:"1",label:"OGNTP"},{value:"8",label:"ADS-L"}],
-		"8": [{value:"6",label:"Latest (FLARM v7)"}],
-		"5": []
+		"8": [{value:"1",label:"OGNTP"},{value:"6",label:"Latest (FLARM v7)"}]
 	};
 	$scope.updateSoftRFCompatProtocols = function() {
 		var primary = $scope.SoftRFProtocol;

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -151,6 +151,7 @@
                             <div class="form-group reset-flow">
                                 <label class="control-label col-xs-5">Primary Protocol</label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFProtocol" ng-change="updateSoftRFCompatProtocols()">
+                                    <option ng-if="!softRFConfigReady" value="-1">Reading from tracker...</option>
                                     <option value="0">Legacy (FLARM)</option>
                                     <option value="1">OGNTP</option>
                                     <option value="6">Latest (FLARM v7)</option>
@@ -163,6 +164,7 @@
                             <div class="form-group reset-flow" ng-show="softRFCompatSecondary.length > 0">
                                 <label class="control-label col-xs-5">Secondary Protocol</label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFAltProtocol">
+                                    <option ng-if="!softRFConfigReady" value="-2">Reading from tracker...</option>
                                     <option value="-1">None</option>
                                     <option ng-repeat="p in softRFCompatSecondary" value="{{p.value}}">{{p.label}}</option>
                                 </select>
@@ -172,6 +174,7 @@
                             <div class="form-group reset-flow">
                                 <label class="control-label col-xs-5">Frequency Band</label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFBand">
+                                    <option ng-if="!softRFConfigReady" value="-1">Reading from tracker...</option>
                                     <option value="1">EU — 868 MHz</option>
                                     <option value="2">US/CA — 915 MHz</option>
                                     <option value="3">AU — 921 MHz</option>
@@ -187,6 +190,7 @@
                             <div class="form-group reset-flow">
                                 <label class="control-label col-xs-5">Alarm Level</label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFAlarm">
+                                    <option ng-if="!softRFConfigReady" value="-1">Reading from tracker...</option>
                                     <option value="0">None</option>
                                     <option value="1">Distance-based</option>
                                     <option value="2">Vector (recommended)</option>
@@ -198,6 +202,7 @@
                             <div class="form-group reset-flow">
                                 <label class="control-label col-xs-5">Relay Mode</label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFRelay">
+                                    <option ng-if="!softRFConfigReady" value="-1">Reading from tracker...</option>
                                     <option value="0">Off</option>
                                     <option value="1">When landed</option>
                                     <option value="2">All traffic</option>
@@ -225,7 +230,8 @@
                         <!-- End SoftRF-specific settings -->
 
                         <div class="form-group reset-flow">
-                            <button class="btn btn-primary btn-block" ng-click="updateOgnTrackerConfig()">Configure Tracker</button>
+                            <button class="btn btn-primary btn-block" ng-click="updateOgnTrackerConfig()" ng-disabled="gpsHardwareCode==13 && !softRFConfigReady">Configure Tracker</button>
+                            <div class="help-block" ng-show="gpsHardwareCode==13 && !softRFConfigReady">Waiting for SoftRF settings readback before applying changes.</div>
                         </div>
                     </form>
                 </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -93,7 +93,7 @@
                                 <option value="0" ng-selected="OGNAddrType=='0'" ng-hide="gpsHardwareCode==15">Random</option>
                                 <option value="1" ng-selected="OGNAddrType=='1'">ICAO</option>
                                 <option value="2" ng-selected="OGNAddrType=='2'">Flarm</option>
-                                <option value="3" ng-selected="OGNAddrType=='3'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">OGN</option>
+                                <option value="3" ng-selected="OGNAddrType=='3'" ng-hide="gpsHardwareCode==15">OGN</option>
                             </select>
                         </div>
 
@@ -111,15 +111,15 @@
                                 <option value="1" ng-selected="OGNAcftType=='1'">Glider/Motorglider</option>
                                 <option value="2" ng-selected="OGNAcftType=='2'" ng-hide="gpsHardwareCode==15">Tow plane</option>
                                 <option value="3" ng-selected="OGNAcftType=='3'">Helicopter</option>
-                                <option value="4" ng-selected="OGNAcftType=='4'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Parachute</option>
-                                <option value="5" ng-selected="OGNAcftType=='5'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Drop plane</option>
+                                <option value="4" ng-selected="OGNAcftType=='4'" ng-hide="gpsHardwareCode==15">Parachute</option>
+                                <option value="5" ng-selected="OGNAcftType=='5'" ng-hide="gpsHardwareCode==15">Drop plane</option>
                                 <option value="6" ng-selected="OGNAcftType=='6'">Hang glider</option>
                                 <option value="7" ng-selected="OGNAcftType=='7'">Para glider</option>
                                 <option value="8" ng-selected="OGNAcftType=='8'">Powered Aircraft</option>
-                                <option value="9" ng-selected="OGNAcftType=='9'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Jet Aircraft</option>
-                                <option value="10" ng-selected="OGNAcftType=='10'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">UFO</option>
+                                <option value="9" ng-selected="OGNAcftType=='9'" ng-hide="gpsHardwareCode==15">Jet Aircraft</option>
+                                <option value="10" ng-selected="OGNAcftType=='10'" ng-hide="gpsHardwareCode==15">UFO</option>
                                 <option value="11" ng-selected="OGNAcftType=='11'">Balloon</option>
-                                <option value="12" ng-selected="OGNAcftType=='12'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Airship</option>
+                                <option value="12" ng-selected="OGNAcftType=='12'" ng-hide="gpsHardwareCode==15">Airship</option>
                                 <option value="13" ng-selected="OGNAcftType=='13'">UAV</option>
                                 <option value="14" ng-selected="OGNAcftType=='14'" ng-hide="gpsHardwareCode==15">Ground support</option>
                                 <option value="15" ng-selected="OGNAcftType=='15'" ng-hide="gpsHardwareCode==15">Static object</option>
@@ -127,20 +127,102 @@
                         </div>
 
                         <!-- Pilot name -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Pilot Name</label>
                             <input class="col-xs-7" type="text" maxlength="15" pilotname-input ng-model="OGNPilot" />
                         </div>
                         <!-- Registration -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Registration</label>
                             <input class="col-xs-7" type="text" maxlength="15" ognreg-input ng-model="OGNReg" />
                         </div>
                         <!-- TX Power -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Transmit Power (dBm)<br/><small>-32 = no transmission, actual power depends on hardware</small></label>
                             <input class="col-xs-7" type="number" min="-32" max="31" ng-model="OGNTxPower" />
                         </div>
+
+                        <!-- SoftRF-specific settings (shown only when SoftRF is detected) -->
+                        <div ng-show="gpsHardwareCode==13">
+
+                            <div class="panel-heading" style="margin-top:10px; margin-bottom:6px; font-weight:bold; font-size:13px; color:#555;">RF Protocol</div>
+
+                            <!-- Primary Protocol -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Primary Protocol</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFProtocol" ng-change="updateSoftRFCompatProtocols()">
+                                    <option value="0">Legacy (FLARM)</option>
+                                    <option value="1">OGNTP</option>
+                                    <option value="6">Latest (FLARM v7)</option>
+                                    <option value="8">ADS-L</option>
+                                    <option value="5">FANET (Skytraxx)</option>
+                                </select>
+                            </div>
+
+                            <!-- Secondary Protocol (filtered by JS based on primary) -->
+                            <div class="form-group reset-flow" ng-show="softRFCompatSecondary.length > 0">
+                                <label class="control-label col-xs-5">Secondary Protocol</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFAltProtocol">
+                                    <option value="-1">None</option>
+                                    <option ng-repeat="p in softRFCompatSecondary" value="{{p.value}}">{{p.label}}</option>
+                                </select>
+                            </div>
+
+                            <!-- Frequency Band -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Frequency Band</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFBand">
+                                    <option value="1">EU — 868 MHz</option>
+                                    <option value="2">US/CA — 915 MHz</option>
+                                    <option value="3">AU — 921 MHz</option>
+                                    <option value="4">NZ — 869 MHz</option>
+                                    <option value="5">RU — 868 MHz</option>
+                                    <option value="7">UK — 869 MHz</option>
+                                </select>
+                            </div>
+
+                            <div class="panel-heading" style="margin-top:10px; margin-bottom:6px; font-weight:bold; font-size:13px; color:#555;">Alarm &amp; Safety</div>
+
+                            <!-- Alarm Level -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Alarm Level</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFAlarm">
+                                    <option value="0">None</option>
+                                    <option value="1">Distance-based</option>
+                                    <option value="2">Vector (recommended)</option>
+                                    <option value="3">FLARM-compatible</option>
+                                </select>
+                            </div>
+
+                            <!-- Relay Mode -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Relay Mode</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFRelay">
+                                    <option value="0">Off</option>
+                                    <option value="1">When landed</option>
+                                    <option value="2">All traffic</option>
+                                    <option value="3">Relay only (no own TX)</option>
+                                </select>
+                            </div>
+
+                            <!-- Stealth -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Stealth Mode<br/><small>Hide from others' displays</small></label>
+                                <div class="col-xs-7">
+                                    <ui-switch ng-model="SoftRFStealth"></ui-switch>
+                                </div>
+                            </div>
+
+                            <!-- No-Track -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">No-Track<br/><small>Opt out of logging</small></label>
+                                <div class="col-xs-7">
+                                    <ui-switch ng-model="SoftRFNoTrack"></ui-switch>
+                                </div>
+                            </div>
+
+                        </div>
+                        <!-- End SoftRF-specific settings -->
 
                         <div class="form-group reset-flow">
                             <button class="btn btn-primary btn-block" ng-click="updateOgnTrackerConfig()">Configure Tracker</button>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -152,11 +152,12 @@
                                 <label class="control-label col-xs-5">Primary Protocol</label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFProtocol" ng-change="updateSoftRFCompatProtocols()">
                                     <option ng-if="!softRFConfigReady" value="-1">Reading from tracker...</option>
-                                    <option value="0">Legacy (FLARM)</option>
                                     <option value="1">OGNTP</option>
+                                    <option value="2">P3I (PilotAware)</option>
+                                    <option value="5">FANET (Skytraxx)</option>
+                                    <option value="0">Legacy (FLARM)</option>
                                     <option value="6">Latest (FLARM v7)</option>
                                     <option value="8">ADS-L</option>
-                                    <option value="5">FANET (Skytraxx)</option>
                                 </select>
                             </div>
 


### PR DESCRIPTION
## Summary

Fixes the SoftRF configuration readback/persistence regression in Stratux and aligns the serial protocol handling with Moshe Braner SoftRF firmware.

## What this does

- prevents unread/placeholder SoftRF values from clobbering saved config
- keeps `Configure Tracker` gated until real tracker values have been read
- translates SoftRF protocol numbering correctly for Moshe Braner firmware on the wire
- preserves existing Stratux-side stored/UI values for backward compatibility

## Notes

Moshe Braner SoftRF uses different protocol numbering on the tracker side than Stratux had assumed. In particular, the tracker-side values for Legacy/Latest and the `altprotocol` field needed translation when reading from and writing to the tracker.

## Validation

Tested on real hardware with a SoftRF connected to Stratux:

- settings accepted by the tracker
- settings persisted across SoftRF reboot
- settings persisted across full Pi reboot
- Stratux `/getSettings` and saved config remained consistent after reboot
