### PR TITLE
Document SoftRF tracker settings in help page

### DIFF
--- a/web/plates/settings-help.html
+++ b/web/plates/settings-help.html
@@ -67,6 +67,15 @@
             elsewhere or pressing <code>ENTER</code>.</span>
         </li>
         <li>
+            <strong>SoftRF Tracker Settings</strong> &mdash; When a compatible SoftRF tracker is connected,
+            additional tracker controls appear on the Settings page. Stratux first reads the current values back
+            from the tracker before allowing configuration changes. <strong>Configure Tracker</strong> writes the
+            selected values to the SoftRF itself, where they should persist across tracker and Stratux reboot.
+            <span class="text-warning">NOTE: If the SoftRF has just powered up, give it a moment to finish
+            starting and refresh the page if the values do not appear immediately. Unsupported primary/secondary
+            protocol combinations are intentionally filtered out.</span>
+        </li>
+        <li>
             <strong>PPM Correction</strong> &mdash; A frequency offset correction value for your SDR dongle.
             Most modern RTL-SDR dongles have low enough error that a value of <strong>0</strong> works well.
             If you suspect PPM error (e.g. consistently missing traffic that others report), try adjusting in


### PR DESCRIPTION
## Summary

Add a short SoftRF tracker section to the Settings help page.

## What changed

- explains that the SoftRF-specific controls only appear when a compatible tracker is detected
- notes that Stratux reads current values back from the tracker before allowing changes
- documents that `Configure Tracker` writes settings to the SoftRF itself and that they should persist across tracker and Stratux reboot
- warns users to wait briefly after SoftRF startup and explains that unsupported protocol combinations are filtered out

## Attribution

These code changes were implemented by GitHub Copilot CLI for @Helno based on the tested behavior of the SoftRF integration.
