### PR TITLE
Add SoftRF RF protocol, band, alarm, relay, stealth and no-track settings

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1244,6 +1244,16 @@ type settings struct {
 	OGNReg               string
 	OGNTxPower           int
 
+	// SoftRF-specific settings (only used when GPS_TYPE_SOFTRF is active)
+	// Values are Moshe Braner SoftRF wire values, stored and sent as-is
+	SoftRFProtocol    int  // 1=OGNTP, 5=FANET, 6=Legacy(FLARM), 7=Latest(FLARMv7), 8=ADS-L
+	SoftRFAltProtocol int  // 0=none, 1=OGNTP, 6=Legacy, 7=Latest, 8=ADS-L
+	SoftRFBand        int  // 1=EU 868MHz, 2=US 915MHz, 3=AU 921MHz, 4=NZ 869MHz, 5=RU 868MHz, 7=UK 869MHz
+	SoftRFAlarm       int  // 0=none, 1=distance, 2=vector, 3=FLARM-compatible
+	SoftRFRelay       int  // 0=off, 1=when landed, 2=all, 3=relay-only
+	SoftRFStealth     bool
+	SoftRFNoTrack     bool
+
 	PWMDutyMin           int
 
 	// manual GPS config  (versus autodetect)
@@ -1376,6 +1386,13 @@ func defaultSettings() {
 	globalSettings.AltitudeOffset = 0
 
 	globalSettings.PWMDutyMin = 0
+	globalSettings.SoftRFProtocol = 7    // default Latest (FLARM v7)
+	globalSettings.SoftRFAltProtocol = 0 // none
+	globalSettings.SoftRFBand = 0        // auto (will be set from RegionSelected on first connect)
+	globalSettings.SoftRFAlarm = 2       // vector (recommended default)
+	globalSettings.SoftRFRelay = 0       // off
+	globalSettings.SoftRFStealth = false
+	globalSettings.SoftRFNoTrack = false
 
 	globalSettings.OGNI2CTXEnabled = true
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1246,11 +1246,12 @@ type settings struct {
 
 	// SoftRF-specific settings (only used when GPS_TYPE_SOFTRF is active)
 	// Values are Moshe Braner SoftRF wire values, stored and sent as-is
-	SoftRFProtocol    int  // 1=OGNTP, 5=FANET, 6=Legacy(FLARM), 7=Latest(FLARMv7), 8=ADS-L
-	SoftRFAltProtocol int  // 0=none, 1=OGNTP, 6=Legacy, 7=Latest, 8=ADS-L
-	SoftRFBand        int  // 1=EU 868MHz, 2=US 915MHz, 3=AU 921MHz, 4=NZ 869MHz, 5=RU 868MHz, 7=UK 869MHz
-	SoftRFAlarm       int  // 0=none, 1=distance, 2=vector, 3=FLARM-compatible
-	SoftRFRelay       int  // 0=off, 1=when landed, 2=all, 3=relay-only
+	SoftRFProtocol    int  // 1=OGNTP,2=P3I,5=FANET,6=Legacy(FLARMv6),7=Latest(FLARMv7),8=ADS-L; -1=unread
+	SoftRFAltProtocol int  // 0=none, or secondary protocol value; -1=unread
+	SoftRFBand        int  // 1=EU,2=US,3=AU,4=NZ,5=RU,6=CN,7=UK,8=IN,9=IL,10=KR; -1=unread
+	SoftRFAlarm       int  // 0=none,1=distance,2=vector,3=FLARM; -1=unread
+	SoftRFRelay       int  // 0=off,1=landed,2=all,3=relay-only; -1=unread
+	SoftRFTxPower     int  // 0=off,1=low,2=full; -1=unread
 	SoftRFStealth     bool
 	SoftRFNoTrack     bool
 
@@ -1386,11 +1387,12 @@ func defaultSettings() {
 	globalSettings.AltitudeOffset = 0
 
 	globalSettings.PWMDutyMin = 0
-	globalSettings.SoftRFProtocol = 7    // default Latest (FLARM v7)
-	globalSettings.SoftRFAltProtocol = 0 // none
-	globalSettings.SoftRFBand = 0        // auto (will be set from RegionSelected on first connect)
-	globalSettings.SoftRFAlarm = 2       // vector (recommended default)
-	globalSettings.SoftRFRelay = 0       // off
+	globalSettings.SoftRFProtocol = -1    // -1 = not yet read from device
+	globalSettings.SoftRFAltProtocol = -1
+	globalSettings.SoftRFBand = -1
+	globalSettings.SoftRFAlarm = -1
+	globalSettings.SoftRFRelay = -1
+	globalSettings.SoftRFTxPower = -1
 	globalSettings.SoftRFStealth = false
 	globalSettings.SoftRFNoTrack = false
 
@@ -1425,6 +1427,21 @@ func readSettings() {
 		return
 	}
 	log.Printf("read in settings.\n")
+
+	// SoftRF old-config migration: Protocol==0 and Band==0 means an old config
+	// with no SoftRF data (both are invalid as zero). Reset all to -1 (unread).
+	if globalSettings.SoftRFProtocol == 0 && globalSettings.SoftRFBand == 0 {
+		globalSettings.SoftRFProtocol = -1
+		globalSettings.SoftRFAltProtocol = -1
+		globalSettings.SoftRFBand = -1
+		globalSettings.SoftRFAlarm = -1
+		globalSettings.SoftRFRelay = -1
+		globalSettings.SoftRFTxPower = -1
+	}
+	// TxPower was added later; reset if zero (invalid) and no SoftRF config saved yet
+	if globalSettings.SoftRFTxPower == 0 && globalSettings.SoftRFProtocol == -1 {
+		globalSettings.SoftRFTxPower = -1
+	}
 }
 
 func addSystemError(err error) {

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -581,6 +581,27 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 					case "OGNTxPower":
 						globalSettings.OGNTxPower = int(val.(float64))
 						reconfigureTracker = true
+					case "SoftRFProtocol":
+						globalSettings.SoftRFProtocol = int(val.(float64))
+						reconfigureTracker = true
+					case "SoftRFAltProtocol":
+						globalSettings.SoftRFAltProtocol = int(val.(float64))
+						reconfigureTracker = true
+					case "SoftRFBand":
+						globalSettings.SoftRFBand = int(val.(float64))
+						reconfigureTracker = true
+					case "SoftRFAlarm":
+						globalSettings.SoftRFAlarm = int(val.(float64))
+						reconfigureTracker = true
+					case "SoftRFRelay":
+						globalSettings.SoftRFRelay = int(val.(float64))
+						reconfigureTracker = true
+					case "SoftRFStealth":
+						globalSettings.SoftRFStealth = val.(bool)
+						reconfigureTracker = true
+					case "SoftRFNoTrack":
+						globalSettings.SoftRFNoTrack = val.(bool)
+						reconfigureTracker = true
 					case "PWMDutyMin":
 						globalSettings.PWMDutyMin = int(val.(float64))
 						reconfigureFancontrol = true

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -582,19 +582,28 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 						globalSettings.OGNTxPower = int(val.(float64))
 						reconfigureTracker = true
 					case "SoftRFProtocol":
-						globalSettings.SoftRFProtocol = int(val.(float64))
+						v := int(val.(float64))
+						if v > 0 { globalSettings.SoftRFProtocol = v }
 						reconfigureTracker = true
 					case "SoftRFAltProtocol":
-						globalSettings.SoftRFAltProtocol = int(val.(float64))
+						v := int(val.(float64))
+						if v >= 0 { globalSettings.SoftRFAltProtocol = v }
 						reconfigureTracker = true
 					case "SoftRFBand":
-						globalSettings.SoftRFBand = int(val.(float64))
+						v := int(val.(float64))
+						if v > 0 { globalSettings.SoftRFBand = v }
 						reconfigureTracker = true
 					case "SoftRFAlarm":
-						globalSettings.SoftRFAlarm = int(val.(float64))
+						v := int(val.(float64))
+						if v >= 0 { globalSettings.SoftRFAlarm = v }
 						reconfigureTracker = true
 					case "SoftRFRelay":
-						globalSettings.SoftRFRelay = int(val.(float64))
+						v := int(val.(float64))
+						if v >= 0 { globalSettings.SoftRFRelay = v }
+						reconfigureTracker = true
+					case "SoftRFTxPower":
+						v := int(val.(float64))
+						if v >= 0 { globalSettings.SoftRFTxPower = v }
 						reconfigureTracker = true
 					case "SoftRFStealth":
 						globalSettings.SoftRFStealth = val.(bool)

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -391,14 +391,7 @@ func (tracker *SoftRF) isDetected() bool {
 }
 
 func (tracker *SoftRF) isConfigRead() bool {
-	// Require the 5 core fields. New MB-specific fields (protocol, band, etc.)
-	// are requested but not required - Linar SoftRF uses a different config format
-	// and won't respond to PSRFS queries.
-	_, hasNmeaG := tracker.settings["nmea_g"]
-	_, hasAcftType := tracker.settings["acft_type"]
-	_, hasIdMethod := tracker.settings["id_method"]
-	_, hasAircraftId := tracker.settings["aircraft_id"]
-	return hasNmeaG && hasAcftType && hasIdMethod && hasAircraftId
+	return len(tracker.settings) >= 8 // need at least 8 settings: acft type, id method, id, nmea1/2 mode, plus some of the new MB SoftRF-specific fields
 }
 
 func (tracker *SoftRF) writeReadDelay() time.Duration {

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -391,7 +391,14 @@ func (tracker *SoftRF) isDetected() bool {
 }
 
 func (tracker *SoftRF) isConfigRead() bool {
-	return len(tracker.settings) >= 8 // need at least 8 settings: acft type, id method, id, nmea1/2 mode, plus some of the new SoftRF-specific fields
+	// Require the 5 core fields. New MB-specific fields (protocol, band, etc.)
+	// are requested but not required - Linar SoftRF uses a different config format
+	// and won't respond to PSRFS queries.
+	_, hasNmeaG := tracker.settings["nmea_g"]
+	_, hasAcftType := tracker.settings["acft_type"]
+	_, hasIdMethod := tracker.settings["id_method"]
+	_, hasAircraftId := tracker.settings["aircraft_id"]
+	return hasNmeaG && hasAcftType && hasIdMethod && hasAircraftId
 }
 
 func (tracker *SoftRF) writeReadDelay() time.Duration {

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -328,11 +328,92 @@ func (tracker *GxAirCom) writeConfigFromSettings(serialPort *serial.Port) bool {
 	return true
 }
 
+var softRFIdentityKeys = []string{"nmea_g", "nmea2_g", "acft_type", "aircraft_id", "id_method"}
+var softRFExtendedKeys = []string{"protocol", "altprotocol", "band", "alarm", "relay", "tx_power", "stealth", "no_track"}
+
 func (tracker *SoftRF) initNewConnection(serialPort *serial.Port) {
 	tracker.detected = false
 	tracker.settings = make(map[string]string)
 }
 
+// softRFSettingChanged returns true if the device's current value for key differs from desired.
+func (tracker *SoftRF) softRFSettingChanged(key, desired string) bool {
+	s, ok := tracker.settings[key]
+	return !ok || s != desired
+}
+
+// applyIdentityToGlobalSettings atomically applies identity config to globalSettings
+// once all identity keys have been received from the device.
+func (tracker *SoftRF) applyIdentityToGlobalSettings() {
+	for _, k := range softRFIdentityKeys {
+		if _, ok := tracker.settings[k]; !ok {
+			return
+		}
+	}
+	acType, err := strconv.Atoi(tracker.settings["acft_type"])
+	if err != nil {
+		return
+	}
+	acType = mapAircraftType(typeMappingOgn2SoftRF, false, acType)
+	if acType < 0 {
+		return
+	}
+	addrType, err := strconv.Atoi(tracker.settings["id_method"])
+	if err != nil || addrType < 0 {
+		return
+	}
+	addr := tracker.settings["aircraft_id"]
+	if addr == "" || addr == "?" {
+		return
+	}
+	globalSettings.OGNAcftType = acType
+	globalSettings.OGNAddrType = addrType
+	globalSettings.OGNAddr = addr
+}
+
+// applyExtendedToGlobalSettings atomically applies extended RF config to globalSettings
+// once all extended keys have been received from the device.
+func (tracker *SoftRF) applyExtendedToGlobalSettings() {
+	for _, k := range softRFExtendedKeys {
+		if _, ok := tracker.settings[k]; !ok {
+			return
+		}
+	}
+	protocol, err := strconv.Atoi(tracker.settings["protocol"])
+	if err != nil || protocol <= 0 {
+		log.Printf("SoftRF: ignoring extended config snapshot: invalid protocol=%q", tracker.settings["protocol"])
+		return
+	}
+	band, err := strconv.Atoi(tracker.settings["band"])
+	if err != nil || band <= 0 {
+		log.Printf("SoftRF: ignoring extended config snapshot: invalid band=%q", tracker.settings["band"])
+		return
+	}
+	altProtocol, err := strconv.Atoi(tracker.settings["altprotocol"])
+	if err != nil {
+		return
+	}
+	alarm, err := strconv.Atoi(tracker.settings["alarm"])
+	if err != nil {
+		return
+	}
+	relay, err := strconv.Atoi(tracker.settings["relay"])
+	if err != nil {
+		return
+	}
+	txPower, err := strconv.Atoi(tracker.settings["tx_power"])
+	if err != nil {
+		return
+	}
+	globalSettings.SoftRFProtocol = protocol
+	globalSettings.SoftRFAltProtocol = altProtocol
+	globalSettings.SoftRFBand = band
+	globalSettings.SoftRFAlarm = alarm
+	globalSettings.SoftRFRelay = relay
+	globalSettings.SoftRFTxPower = txPower
+	globalSettings.SoftRFStealth = tracker.settings["stealth"] == "1"
+	globalSettings.SoftRFNoTrack = tracker.settings["no_track"] == "1"
+}
 
 func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 	if nmea[0] == "PSRFH" {
@@ -347,51 +428,43 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 	// See output of $PSRFS,0,?*4B
 	if nmea[0] == "PSRFS" {
 		key, value := nmea[2], nmea[3]
+		if value == "?" {
+			return true // ignore query echoes
+		}
 		log.Printf("Received SoftRF config %s=%s", key, value)
 		tracker.settings[key] = value
-		if key == "acft_type" {
-			acType, _ := strconv.Atoi(value)
-			acType = mapAircraftType(typeMappingOgn2SoftRF, false, acType)
-			globalSettings.OGNAcftType = acType
-		} else if key == "id_method" {
-			globalSettings.OGNAddrType, _ = strconv.Atoi(value)
-		} else if key == "aircraft_id" {
-			globalSettings.OGNAddr = value
-		} else if key == "protocol" {
-			globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
-		} else if key == "altprotocol" {
-			globalSettings.SoftRFAltProtocol, _ = strconv.Atoi(value)
-		} else if key == "band" {
-			globalSettings.SoftRFBand, _ = strconv.Atoi(value)
-		} else if key == "alarm" {
-			globalSettings.SoftRFAlarm, _ = strconv.Atoi(value)
-		} else if key == "relay" {
-			globalSettings.SoftRFRelay, _ = strconv.Atoi(value)
-		} else if key == "stealth" {
-			globalSettings.SoftRFStealth = value == "1"
-		} else if key == "no_track" {
-			globalSettings.SoftRFNoTrack = value == "1"
-		}
+		tracker.applyIdentityToGlobalSettings()
+		tracker.applyExtendedToGlobalSettings()
 		return true
 	}
 
 	return false
-
 }
+
 func (tracker *SoftRF) gpsTimeOffsetPps() time.Duration {
 	return 200 * time.Millisecond
 }
 
 func (tracker *SoftRF) getGpsHardwareType() uint {
 	return GPS_TYPE_SOFTRF
-	
 }
+
 func (tracker *SoftRF) isDetected() bool {
 	return tracker.detected
 }
 
 func (tracker *SoftRF) isConfigRead() bool {
-	return len(tracker.settings) >= 8 // need at least 8 settings: acft type, id method, id, nmea1/2 mode, plus some of the new MB SoftRF-specific fields
+	for _, k := range softRFIdentityKeys {
+		if _, ok := tracker.settings[k]; !ok {
+			return false
+		}
+	}
+	for _, k := range softRFExtendedKeys {
+		if _, ok := tracker.settings[k]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (tracker *SoftRF) writeReadDelay() time.Duration {
@@ -422,18 +495,10 @@ func (tracker *SoftRF) writeInitialConfig(serialPort *serial.Port) bool {
 }
 
 func (tracker *SoftRF) requestTrackerConfig(serialPort *serial.Port) {
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,nmea_g,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,nmea2_g,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,acft_type,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,aircraft_id,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,id_method,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,protocol,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,altprotocol,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,band,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,alarm,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,relay,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,stealth,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,no_track,?") + "\r\n"))
+	keys := append(softRFIdentityKeys, softRFExtendedKeys...)
+	for _, key := range keys {
+		serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,"+key+",?") + "\r\n"))
+	}
 }
 
 func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
@@ -447,54 +512,66 @@ func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
 
 	var messages []string
 
-	if s, ok := tracker.settings["acft_type"]; !ok || acType != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,acft_type," + acType) + "\r\n")
+	if tracker.softRFSettingChanged("acft_type", acType) {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,acft_type,"+acType)+"\r\n")
 	}
-	if s, ok := tracker.settings["id_method"]; !ok || addrType != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,id_method," + addrType) + "\r\n")
+	if tracker.softRFSettingChanged("id_method", addrType) {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,id_method,"+addrType)+"\r\n")
 	}
-	if s, ok := tracker.settings["aircraft_id"]; !ok || addr != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,aircraft_id," + addr) + "\r\n")
+	if tracker.softRFSettingChanged("aircraft_id", addr) {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,aircraft_id,"+addr)+"\r\n")
 	}
 
 	// RF protocol (wire values from Moshe Braner SoftRF, stored and sent as-is)
 	if globalSettings.SoftRFProtocol > 0 {
 		proto := strconv.Itoa(globalSettings.SoftRFProtocol)
-		if s, ok := tracker.settings["protocol"]; !ok || proto != s {
-			messages = append(messages, appendNmeaChecksum("$PSRFS,0,protocol," + proto) + "\r\n")
+		if tracker.softRFSettingChanged("protocol", proto) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,protocol,"+proto)+"\r\n")
 		}
 	}
-	altProto := strconv.Itoa(globalSettings.SoftRFAltProtocol)
-	if s, ok := tracker.settings["altprotocol"]; !ok || altProto != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,altprotocol," + altProto) + "\r\n")
+	if globalSettings.SoftRFAltProtocol >= 0 {
+		altProto := strconv.Itoa(globalSettings.SoftRFAltProtocol)
+		if tracker.softRFSettingChanged("altprotocol", altProto) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,altprotocol,"+altProto)+"\r\n")
+		}
 	}
 	if globalSettings.SoftRFBand > 0 {
 		band := strconv.Itoa(globalSettings.SoftRFBand)
-		if s, ok := tracker.settings["band"]; !ok || band != s {
-			messages = append(messages, appendNmeaChecksum("$PSRFS,0,band," + band) + "\r\n")
+		if tracker.softRFSettingChanged("band", band) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,band,"+band)+"\r\n")
 		}
 	}
-	alarm := strconv.Itoa(globalSettings.SoftRFAlarm)
-	if s, ok := tracker.settings["alarm"]; !ok || alarm != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,alarm," + alarm) + "\r\n")
+	if globalSettings.SoftRFAlarm >= 0 {
+		alarm := strconv.Itoa(globalSettings.SoftRFAlarm)
+		if tracker.softRFSettingChanged("alarm", alarm) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,alarm,"+alarm)+"\r\n")
+		}
 	}
-	relay := strconv.Itoa(globalSettings.SoftRFRelay)
-	if s, ok := tracker.settings["relay"]; !ok || relay != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,relay," + relay) + "\r\n")
+	if globalSettings.SoftRFRelay >= 0 {
+		relay := strconv.Itoa(globalSettings.SoftRFRelay)
+		if tracker.softRFSettingChanged("relay", relay) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,relay,"+relay)+"\r\n")
+		}
+	}
+	if globalSettings.SoftRFTxPower >= 0 {
+		txPower := strconv.Itoa(globalSettings.SoftRFTxPower)
+		if tracker.softRFSettingChanged("tx_power", txPower) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,tx_power,"+txPower)+"\r\n")
+		}
 	}
 	stealth := "0"
 	if globalSettings.SoftRFStealth {
 		stealth = "1"
 	}
-	if s, ok := tracker.settings["stealth"]; !ok || stealth != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,stealth," + stealth) + "\r\n")
+	if tracker.softRFSettingChanged("stealth", stealth) {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,stealth,"+stealth)+"\r\n")
 	}
 	noTrack := "0"
 	if globalSettings.SoftRFNoTrack {
 		noTrack = "1"
 	}
-	if s, ok := tracker.settings["no_track"]; !ok || noTrack != s {
-		messages = append(messages, appendNmeaChecksum("$PSRFS,0,no_track," + noTrack) + "\r\n")
+	if tracker.softRFSettingChanged("no_track", noTrack) {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,no_track,"+noTrack)+"\r\n")
 	}
 
 	for _, msg := range messages {

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -357,6 +357,20 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 			globalSettings.OGNAddrType, _ = strconv.Atoi(value)
 		} else if key == "aircraft_id" {
 			globalSettings.OGNAddr = value
+		} else if key == "protocol" {
+			globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
+		} else if key == "altprotocol" {
+			globalSettings.SoftRFAltProtocol, _ = strconv.Atoi(value)
+		} else if key == "band" {
+			globalSettings.SoftRFBand, _ = strconv.Atoi(value)
+		} else if key == "alarm" {
+			globalSettings.SoftRFAlarm, _ = strconv.Atoi(value)
+		} else if key == "relay" {
+			globalSettings.SoftRFRelay, _ = strconv.Atoi(value)
+		} else if key == "stealth" {
+			globalSettings.SoftRFStealth = value == "1"
+		} else if key == "no_track" {
+			globalSettings.SoftRFNoTrack = value == "1"
 		}
 		return true
 	}
@@ -377,7 +391,7 @@ func (tracker *SoftRF) isDetected() bool {
 }
 
 func (tracker *SoftRF) isConfigRead() bool {
-	return len(tracker.settings) >= 5 // need at least or 5 main settings: acft type, id method and id, as well as nmea1/2 mode
+	return len(tracker.settings) >= 8 // need at least 8 settings: acft type, id method, id, nmea1/2 mode, plus some of the new SoftRF-specific fields
 }
 
 func (tracker *SoftRF) writeReadDelay() time.Duration {
@@ -413,6 +427,13 @@ func (tracker *SoftRF) requestTrackerConfig(serialPort *serial.Port) {
 	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,acft_type,?") + "\r\n"))
 	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,aircraft_id,?") + "\r\n"))
 	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,id_method,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,protocol,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,altprotocol,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,band,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,alarm,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,relay,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,stealth,?") + "\r\n"))
+	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,no_track,?") + "\r\n"))
 }
 
 func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
@@ -434,6 +455,46 @@ func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
 	}
 	if s, ok := tracker.settings["aircraft_id"]; !ok || addr != s {
 		messages = append(messages, appendNmeaChecksum("$PSRFS,0,aircraft_id," + addr) + "\r\n")
+	}
+
+	// RF protocol (wire values from Moshe Braner SoftRF, stored and sent as-is)
+	if globalSettings.SoftRFProtocol > 0 {
+		proto := strconv.Itoa(globalSettings.SoftRFProtocol)
+		if s, ok := tracker.settings["protocol"]; !ok || proto != s {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,protocol," + proto) + "\r\n")
+		}
+	}
+	altProto := strconv.Itoa(globalSettings.SoftRFAltProtocol)
+	if s, ok := tracker.settings["altprotocol"]; !ok || altProto != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,altprotocol," + altProto) + "\r\n")
+	}
+	if globalSettings.SoftRFBand > 0 {
+		band := strconv.Itoa(globalSettings.SoftRFBand)
+		if s, ok := tracker.settings["band"]; !ok || band != s {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,band," + band) + "\r\n")
+		}
+	}
+	alarm := strconv.Itoa(globalSettings.SoftRFAlarm)
+	if s, ok := tracker.settings["alarm"]; !ok || alarm != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,alarm," + alarm) + "\r\n")
+	}
+	relay := strconv.Itoa(globalSettings.SoftRFRelay)
+	if s, ok := tracker.settings["relay"]; !ok || relay != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,relay," + relay) + "\r\n")
+	}
+	stealth := "0"
+	if globalSettings.SoftRFStealth {
+		stealth = "1"
+	}
+	if s, ok := tracker.settings["stealth"]; !ok || stealth != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,stealth," + stealth) + "\r\n")
+	}
+	noTrack := "0"
+	if globalSettings.SoftRFNoTrack {
+		noTrack = "1"
+	}
+	if s, ok := tracker.settings["no_track"]; !ok || noTrack != s {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,no_track," + noTrack) + "\r\n")
 	}
 
 	for _, msg := range messages {

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -343,14 +343,17 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.OGNReg = settings.OGNReg;
 		$scope.OGNTxPower = settings.OGNTxPower;
 
-		// SoftRF-specific settings (wire values from Moshe Braner SoftRF)
-		$scope.SoftRFProtocol = (settings.SoftRFProtocol || 7).toString();
-		$scope.SoftRFAltProtocol = (settings.SoftRFAltProtocol !== undefined ? settings.SoftRFAltProtocol : 0).toString();
-		$scope.SoftRFBand = (settings.SoftRFBand || 0).toString();
-		$scope.SoftRFAlarm = (settings.SoftRFAlarm !== undefined ? settings.SoftRFAlarm : 2).toString();
-		$scope.SoftRFRelay = (settings.SoftRFRelay || 0).toString();
+		// SoftRF-specific settings (wire values from Moshe Braner SoftRF; -1 = not yet read from device)
+		$scope.SoftRFProtocol = (settings.SoftRFProtocol > 0) ? settings.SoftRFProtocol.toString() : "7";
+		$scope.SoftRFAltProtocol = (settings.SoftRFAltProtocol >= 0) ? settings.SoftRFAltProtocol.toString() : "0";
+		$scope.SoftRFBand = (settings.SoftRFBand > 0) ? settings.SoftRFBand.toString() : defaultSoftRFBand(settings.RegionSelected).toString();
+		$scope.SoftRFAlarm = (settings.SoftRFAlarm >= 0) ? settings.SoftRFAlarm.toString() : "3";
+		$scope.SoftRFRelay = (settings.SoftRFRelay >= 0) ? settings.SoftRFRelay.toString() : "0";
+		$scope.SoftRFTxPower = (settings.SoftRFTxPower >= 0) ? settings.SoftRFTxPower.toString() : "2";
 		$scope.SoftRFStealth = settings.SoftRFStealth || false;
 		$scope.SoftRFNoTrack = settings.SoftRFNoTrack || false;
+		$scope.softRFConfigReady = settings.SoftRFProtocol > 0 && settings.SoftRFBand > 0;
+		$scope.updateSoftRFCompatProtocols();
 
 		$scope.PWMDutyMin = settings.PWMDutyMin;
 
@@ -719,6 +722,34 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		return "???";
 	}
 
+	function defaultSoftRFBand(region) {
+		switch (parseInt(region)) {
+			case 1: return 2;  // US -> 915 MHz
+			case 2: return 1;  // EU -> 868 MHz
+			default: return 1; // default EU
+		}
+	}
+
+	// Protocol compatibility: primary -> allowed alt protocol values (as object keys for fast lookup)
+	var softRFCompatMap = {
+		"7": {"1":true,"2":true,"5":true,"6":true,"8":true},  // Latest: all others
+		"6": {"1":true,"7":true,"8":true},                    // Legacy: OGNTP, Latest, ADS-L
+		"1": {"2":true,"5":true,"6":true,"7":true,"8":true},  // OGNTP: P3I, FANET, Legacy, Latest, ADS-L
+		"2": {"1":true,"7":true,"8":true},                    // P3I: OGNTP, Latest, ADS-L
+		"5": {"1":true,"7":true,"8":true},                    // FANET: OGNTP, Latest, ADS-L
+		"8": {"1":true,"2":true,"5":true,"6":true,"7":true}   // ADS-L: all others
+	};
+
+	$scope.updateSoftRFCompatProtocols = function() {
+		var proto = $scope.SoftRFProtocol;
+		var allowed = softRFCompatMap[proto] || {};
+		$scope.softRFAltProtoAllowed = allowed;
+		// If current alt selection is no longer valid, reset to None
+		if ($scope.SoftRFAltProtocol !== "0" && !allowed[$scope.SoftRFAltProtocol]) {
+			$scope.SoftRFAltProtocol = "0";
+		}
+	};
+
 	$scope.updateOgnTrackerConfig = function(action) {
 		var newsettings = {
 			"OGNAddrType": parseInt($scope.OGNAddrType),
@@ -726,15 +757,19 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			"OGNAcftType": parseInt($scope.OGNAcftType),
 			"OGNPilot": $scope.OGNPilot,
 			"OGNReg": $scope.OGNReg,
-			"OGNTxPower": $scope.OGNTxPower,
-			"SoftRFProtocol": parseInt($scope.SoftRFProtocol),
-			"SoftRFAltProtocol": parseInt($scope.SoftRFAltProtocol),
-			"SoftRFBand": parseInt($scope.SoftRFBand),
-			"SoftRFAlarm": parseInt($scope.SoftRFAlarm),
-			"SoftRFRelay": parseInt($scope.SoftRFRelay),
-			"SoftRFStealth": $scope.SoftRFStealth,
-			"SoftRFNoTrack": $scope.SoftRFNoTrack
+			"OGNTxPower": $scope.OGNTxPower
 		};
+		// Only include SoftRF settings when a SoftRF device is connected
+		if (parseInt($scope.gpsHardwareCode) === 13) {
+			newsettings["SoftRFProtocol"] = parseInt($scope.SoftRFProtocol);
+			newsettings["SoftRFAltProtocol"] = parseInt($scope.SoftRFAltProtocol);
+			newsettings["SoftRFBand"] = parseInt($scope.SoftRFBand);
+			newsettings["SoftRFAlarm"] = parseInt($scope.SoftRFAlarm);
+			newsettings["SoftRFRelay"] = parseInt($scope.SoftRFRelay);
+			newsettings["SoftRFTxPower"] = parseInt($scope.SoftRFTxPower);
+			newsettings["SoftRFStealth"] = $scope.SoftRFStealth;
+			newsettings["SoftRFNoTrack"] = $scope.SoftRFNoTrack;
+		}
 		setSettings(angular.toJson(newsettings));
 
 		// reload settings after a short time, to check if OGN tracker actually accepted the settings

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -343,6 +343,15 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.OGNReg = settings.OGNReg;
 		$scope.OGNTxPower = settings.OGNTxPower;
 
+		// SoftRF-specific settings (wire values from Moshe Braner SoftRF)
+		$scope.SoftRFProtocol = (settings.SoftRFProtocol || 7).toString();
+		$scope.SoftRFAltProtocol = (settings.SoftRFAltProtocol !== undefined ? settings.SoftRFAltProtocol : 0).toString();
+		$scope.SoftRFBand = (settings.SoftRFBand || 0).toString();
+		$scope.SoftRFAlarm = (settings.SoftRFAlarm !== undefined ? settings.SoftRFAlarm : 2).toString();
+		$scope.SoftRFRelay = (settings.SoftRFRelay || 0).toString();
+		$scope.SoftRFStealth = settings.SoftRFStealth || false;
+		$scope.SoftRFNoTrack = settings.SoftRFNoTrack || false;
+
 		$scope.PWMDutyMin = settings.PWMDutyMin;
 
 		// Update theme
@@ -717,7 +726,14 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			"OGNAcftType": parseInt($scope.OGNAcftType),
 			"OGNPilot": $scope.OGNPilot,
 			"OGNReg": $scope.OGNReg,
-			"OGNTxPower": $scope.OGNTxPower
+			"OGNTxPower": $scope.OGNTxPower,
+			"SoftRFProtocol": parseInt($scope.SoftRFProtocol),
+			"SoftRFAltProtocol": parseInt($scope.SoftRFAltProtocol),
+			"SoftRFBand": parseInt($scope.SoftRFBand),
+			"SoftRFAlarm": parseInt($scope.SoftRFAlarm),
+			"SoftRFRelay": parseInt($scope.SoftRFRelay),
+			"SoftRFStealth": $scope.SoftRFStealth,
+			"SoftRFNoTrack": $scope.SoftRFNoTrack
 		};
 		setSettings(angular.toJson(newsettings));
 

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -93,7 +93,7 @@
                                 <option value="0" ng-selected="OGNAddrType=='0'" ng-hide="gpsHardwareCode==15">Random</option>
                                 <option value="1" ng-selected="OGNAddrType=='1'">ICAO</option>
                                 <option value="2" ng-selected="OGNAddrType=='2'">Flarm</option>
-                                <option value="3" ng-selected="OGNAddrType=='3'" ng-hide="gpsHardwareCode==15">OGN</option>
+                                <option value="3" ng-selected="OGNAddrType=='3'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">OGN</option>
                             </select>
                         </div>
 

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -111,15 +111,15 @@
                                 <option value="1" ng-selected="OGNAcftType=='1'">Glider/Motorglider</option>
                                 <option value="2" ng-selected="OGNAcftType=='2'" ng-hide="gpsHardwareCode==15">Tow plane</option>
                                 <option value="3" ng-selected="OGNAcftType=='3'">Helicopter</option>
-                                <option value="4" ng-selected="OGNAcftType=='4'" ng-hide="gpsHardwareCode==15">Parachute</option>
-                                <option value="5" ng-selected="OGNAcftType=='5'" ng-hide="gpsHardwareCode==15">Drop plane</option>
+                                <option value="4" ng-selected="OGNAcftType=='4'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Parachute</option>
+                                <option value="5" ng-selected="OGNAcftType=='5'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Drop plane</option>
                                 <option value="6" ng-selected="OGNAcftType=='6'">Hang glider</option>
                                 <option value="7" ng-selected="OGNAcftType=='7'">Para glider</option>
                                 <option value="8" ng-selected="OGNAcftType=='8'">Powered Aircraft</option>
-                                <option value="9" ng-selected="OGNAcftType=='9'" ng-hide="gpsHardwareCode==15">Jet Aircraft</option>
-                                <option value="10" ng-selected="OGNAcftType=='10'" ng-hide="gpsHardwareCode==15">UFO</option>
+                                <option value="9" ng-selected="OGNAcftType=='9'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Jet Aircraft</option>
+                                <option value="10" ng-selected="OGNAcftType=='10'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">UFO</option>
                                 <option value="11" ng-selected="OGNAcftType=='11'">Balloon</option>
-                                <option value="12" ng-selected="OGNAcftType=='12'" ng-hide="gpsHardwareCode==15">Airship</option>
+                                <option value="12" ng-selected="OGNAcftType=='12'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Airship</option>
                                 <option value="13" ng-selected="OGNAcftType=='13'">UAV</option>
                                 <option value="14" ng-selected="OGNAcftType=='14'" ng-hide="gpsHardwareCode==15">Ground support</option>
                                 <option value="15" ng-selected="OGNAcftType=='15'" ng-hide="gpsHardwareCode==15">Static object</option>
@@ -127,17 +127,17 @@
                         </div>
 
                         <!-- Pilot name -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13">
                             <label class="control-label col-xs-5">Pilot Name</label>
                             <input class="col-xs-7" type="text" maxlength="15" pilotname-input ng-model="OGNPilot" />
                         </div>
                         <!-- Registration -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Registration</label>
                             <input class="col-xs-7" type="text" maxlength="15" ognreg-input ng-model="OGNReg" />
                         </div>
                         <!-- TX Power -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Transmit Power (dBm)<br/><small>-32 = no transmission, actual power depends on hardware</small></label>
                             <input class="col-xs-7" type="number" min="-32" max="31" ng-model="OGNTxPower" />
                         </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -88,18 +88,20 @@
                     <form name="OGNTrackerSettings" novalidate>
                         <!-- Address Type -->
                         <div class="form-group reset-flow">
-                            <label class="control-label col-xs-5">Tracker Address Type</label>
+                            <label class="control-label col-xs-5">{{gpsHardwareCode==13 ? 'ID Type' : 'Tracker Address Type'}}</label>
                             <select class="col-xs-7 custom-select" ng-model="OGNAddrType">
                                 <option value="0" ng-selected="OGNAddrType=='0'" ng-hide="gpsHardwareCode==15">Random</option>
                                 <option value="1" ng-selected="OGNAddrType=='1'">ICAO</option>
-                                <option value="2" ng-selected="OGNAddrType=='2'">Flarm</option>
+                                <option value="2" ng-selected="OGNAddrType=='2'">{{gpsHardwareCode==13 ? 'Device' : 'Flarm'}}</option>
                                 <option value="3" ng-selected="OGNAddrType=='3'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">OGN</option>
+                                <option value="3" ng-selected="OGNAddrType=='3'" ng-show="gpsHardwareCode==13">Anonymous</option>
+                                <option value="7" ng-selected="OGNAddrType=='7'" ng-show="gpsHardwareCode==13">Override device ID</option>
                             </select>
                         </div>
 
                         <!-- Address -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 && OGNAddrType != '1'">
-                            <label class="control-label col-xs-5">Tracker Address (Hex)</label>
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 && OGNAddrType != '1' && OGNAddrType != '7'">
+                            <label class="control-label col-xs-5">{{gpsHardwareCode==13 ? 'Aircraft ID (Hex)' : 'Tracker Address (Hex)'}}</label>
                             <input class="col-xs-7" type="text" maxlength="6" hex-input ng-model="OGNAddr" />
                         </div>
 
@@ -121,22 +123,22 @@
                                 <option value="11" ng-selected="OGNAcftType=='11'">Balloon</option>
                                 <option value="12" ng-selected="OGNAcftType=='12'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Airship</option>
                                 <option value="13" ng-selected="OGNAcftType=='13'">UAV</option>
-                                <option value="14" ng-selected="OGNAcftType=='14'" ng-hide="gpsHardwareCode==15">Ground support</option>
+                                <option value="14" ng-selected="OGNAcftType=='14'" ng-hide="gpsHardwareCode==15">{{gpsHardwareCode==13 ? 'Ground support / Winch' : 'Ground support'}}</option>
                                 <option value="15" ng-selected="OGNAcftType=='15'" ng-hide="gpsHardwareCode==15">Static object</option>
                             </select>
                         </div>
 
                         <!-- Pilot name -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Pilot Name</label>
                             <input class="col-xs-7" type="text" maxlength="15" pilotname-input ng-model="OGNPilot" />
                         </div>
                         <!-- Registration -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Registration</label>
                             <input class="col-xs-7" type="text" maxlength="15" ognreg-input ng-model="OGNReg" />
                         </div>
-                        <!-- TX Power -->
+                        <!-- TX Power (OGN/GX only) -->
                         <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Transmit Power (dBm)<br/><small>-32 = no transmission, actual power depends on hardware</small></label>
                             <input class="col-xs-7" type="number" min="-32" max="31" ng-model="OGNTxPower" />
@@ -149,24 +151,27 @@
                             <!-- Primary Protocol -->
                             <div class="form-group reset-flow">
                                 <label class="control-label col-xs-5">Primary Protocol</label>
-                                <select class="col-xs-7 custom-select" ng-model="SoftRFProtocol">
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFProtocol" ng-change="updateSoftRFCompatProtocols()">
                                     <option value="7">Latest (FLARM v7)</option>
-                                    <option value="6">Legacy (FLARM)</option>
+                                    <option value="6">Legacy (FLARM v6)</option>
                                     <option value="1">OGNTP</option>
+                                    <option value="2">P3I (PilotAware)</option>
                                     <option value="5">FANET (Skytraxx)</option>
                                     <option value="8">ADS-L</option>
                                 </select>
                             </div>
 
-                            <!-- Secondary Protocol -->
+                            <!-- Alternate Protocol (flat options, filtered by softRFAltProtoAllowed) -->
                             <div class="form-group reset-flow">
-                                <label class="control-label col-xs-5">Secondary Protocol<br/><small>Transmit in alt protocol every 4s</small></label>
+                                <label class="control-label col-xs-5">Alternate Protocol<br/><small>Transmit in alt protocol every 4s</small></label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFAltProtocol">
                                     <option value="0">None</option>
-                                    <option value="7">Latest (FLARM v7)</option>
-                                    <option value="6">Legacy (FLARM)</option>
-                                    <option value="1">OGNTP</option>
-                                    <option value="8">ADS-L</option>
+                                    <option value="1" ng-show="softRFAltProtoAllowed['1']">OGNTP</option>
+                                    <option value="2" ng-show="softRFAltProtoAllowed['2']">P3I (PilotAware)</option>
+                                    <option value="5" ng-show="softRFAltProtoAllowed['5']">FANET</option>
+                                    <option value="6" ng-show="softRFAltProtoAllowed['6']">Legacy (FLARM v6)</option>
+                                    <option value="7" ng-show="softRFAltProtoAllowed['7']">Latest (FLARM v7)</option>
+                                    <option value="8" ng-show="softRFAltProtoAllowed['8']">ADS-L</option>
                                 </select>
                             </div>
 
@@ -174,13 +179,26 @@
                             <div class="form-group reset-flow">
                                 <label class="control-label col-xs-5">Frequency Band</label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFBand">
-                                    <option value="0">Auto (from region setting)</option>
                                     <option value="1">EU — 868 MHz</option>
                                     <option value="2">US/CA — 915 MHz</option>
                                     <option value="3">AU — 921 MHz</option>
                                     <option value="4">NZ — 869 MHz</option>
                                     <option value="5">RU — 868 MHz</option>
+                                    <option value="6">CN — 470 MHz</option>
                                     <option value="7">UK — 869 MHz</option>
+                                    <option value="8">IN — 866 MHz</option>
+                                    <option value="9">IL — 916 MHz</option>
+                                    <option value="10">KR — 920 MHz</option>
+                                </select>
+                            </div>
+
+                            <!-- TX Power -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">TX Power</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFTxPower">
+                                    <option value="2">Full</option>
+                                    <option value="1">Low</option>
+                                    <option value="0">Off (receive only)</option>
                                 </select>
                             </div>
 
@@ -188,12 +206,12 @@
 
                             <!-- Alarm Level -->
                             <div class="form-group reset-flow">
-                                <label class="control-label col-xs-5">Alarm Level</label>
+                                <label class="control-label col-xs-5">Alarm Method</label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFAlarm">
+                                    <option value="3">FLARM</option>
+                                    <option value="2">Vector</option>
+                                    <option value="1">Distance</option>
                                     <option value="0">None</option>
-                                    <option value="1">Distance-based</option>
-                                    <option value="2">Vector (recommended)</option>
-                                    <option value="3">FLARM-compatible</option>
                                 </select>
                             </div>
 
@@ -202,7 +220,7 @@
                                 <label class="control-label col-xs-5">Relay Mode</label>
                                 <select class="col-xs-7 custom-select" ng-model="SoftRFRelay">
                                     <option value="0">Off</option>
-                                    <option value="1">When landed (opt-in)</option>
+                                    <option value="1">Landed</option>
                                     <option value="2">All traffic</option>
                                     <option value="3">Relay only (no own TX)</option>
                                 </select>
@@ -227,7 +245,9 @@
                         <!-- End SoftRF-specific settings -->
 
                         <div class="form-group reset-flow">
-                            <button class="btn btn-primary btn-block" ng-click="updateOgnTrackerConfig()">Configure Tracker</button>
+                            <button class="btn btn-primary btn-block" ng-click="updateOgnTrackerConfig()"
+                                    ng-disabled="gpsHardwareCode==13 && !softRFConfigReady">Configure Tracker</button>
+                            <div class="help-block" ng-show="gpsHardwareCode==13 && !softRFConfigReady">Waiting for SoftRF settings readback&hellip;</div>
                         </div>
                     </form>
                 </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -93,7 +93,7 @@
                                 <option value="0" ng-selected="OGNAddrType=='0'" ng-hide="gpsHardwareCode==15">Random</option>
                                 <option value="1" ng-selected="OGNAddrType=='1'">ICAO</option>
                                 <option value="2" ng-selected="OGNAddrType=='2'">Flarm</option>
-                                <option value="3" ng-selected="OGNAddrType=='3'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">OGN</option>
+                                <option value="3" ng-selected="OGNAddrType=='3'" ng-hide="gpsHardwareCode==15">OGN</option>
                             </select>
                         </div>
 
@@ -111,15 +111,15 @@
                                 <option value="1" ng-selected="OGNAcftType=='1'">Glider/Motorglider</option>
                                 <option value="2" ng-selected="OGNAcftType=='2'" ng-hide="gpsHardwareCode==15">Tow plane</option>
                                 <option value="3" ng-selected="OGNAcftType=='3'">Helicopter</option>
-                                <option value="4" ng-selected="OGNAcftType=='4'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Parachute</option>
-                                <option value="5" ng-selected="OGNAcftType=='5'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Drop plane</option>
+                                <option value="4" ng-selected="OGNAcftType=='4'" ng-hide="gpsHardwareCode==15">Parachute</option>
+                                <option value="5" ng-selected="OGNAcftType=='5'" ng-hide="gpsHardwareCode==15">Drop plane</option>
                                 <option value="6" ng-selected="OGNAcftType=='6'">Hang glider</option>
                                 <option value="7" ng-selected="OGNAcftType=='7'">Para glider</option>
                                 <option value="8" ng-selected="OGNAcftType=='8'">Powered Aircraft</option>
-                                <option value="9" ng-selected="OGNAcftType=='9'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Jet Aircraft</option>
-                                <option value="10" ng-selected="OGNAcftType=='10'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">UFO</option>
+                                <option value="9" ng-selected="OGNAcftType=='9'" ng-hide="gpsHardwareCode==15">Jet Aircraft</option>
+                                <option value="10" ng-selected="OGNAcftType=='10'" ng-hide="gpsHardwareCode==15">UFO</option>
                                 <option value="11" ng-selected="OGNAcftType=='11'">Balloon</option>
-                                <option value="12" ng-selected="OGNAcftType=='12'" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">Airship</option>
+                                <option value="12" ng-selected="OGNAcftType=='12'" ng-hide="gpsHardwareCode==15">Airship</option>
                                 <option value="13" ng-selected="OGNAcftType=='13'">UAV</option>
                                 <option value="14" ng-selected="OGNAcftType=='14'" ng-hide="gpsHardwareCode==15">Ground support</option>
                                 <option value="15" ng-selected="OGNAcftType=='15'" ng-hide="gpsHardwareCode==15">Static object</option>
@@ -127,20 +127,104 @@
                         </div>
 
                         <!-- Pilot name -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Pilot Name</label>
                             <input class="col-xs-7" type="text" maxlength="15" pilotname-input ng-model="OGNPilot" />
                         </div>
                         <!-- Registration -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Registration</label>
                             <input class="col-xs-7" type="text" maxlength="15" ognreg-input ng-model="OGNReg" />
                         </div>
                         <!-- TX Power -->
-                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">
+                        <div class="form-group reset-flow" ng-hide="gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Transmit Power (dBm)<br/><small>-32 = no transmission, actual power depends on hardware</small></label>
                             <input class="col-xs-7" type="number" min="-32" max="31" ng-model="OGNTxPower" />
                         </div>
+
+                        <!-- SoftRF-specific settings (shown only when SoftRF is detected, hardware code 13) -->
+                        <div ng-show="gpsHardwareCode==13">
+                            <div style="margin-top:12px; margin-bottom:6px; font-weight:bold; font-size:13px; color:#555;">RF Protocol</div>
+
+                            <!-- Primary Protocol -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Primary Protocol</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFProtocol">
+                                    <option value="7">Latest (FLARM v7)</option>
+                                    <option value="6">Legacy (FLARM)</option>
+                                    <option value="1">OGNTP</option>
+                                    <option value="5">FANET (Skytraxx)</option>
+                                    <option value="8">ADS-L</option>
+                                </select>
+                            </div>
+
+                            <!-- Secondary Protocol -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Secondary Protocol<br/><small>Transmit in alt protocol every 4s</small></label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFAltProtocol">
+                                    <option value="0">None</option>
+                                    <option value="7">Latest (FLARM v7)</option>
+                                    <option value="6">Legacy (FLARM)</option>
+                                    <option value="1">OGNTP</option>
+                                    <option value="8">ADS-L</option>
+                                </select>
+                            </div>
+
+                            <!-- Frequency Band -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Frequency Band</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFBand">
+                                    <option value="0">Auto (from region setting)</option>
+                                    <option value="1">EU — 868 MHz</option>
+                                    <option value="2">US/CA — 915 MHz</option>
+                                    <option value="3">AU — 921 MHz</option>
+                                    <option value="4">NZ — 869 MHz</option>
+                                    <option value="5">RU — 868 MHz</option>
+                                    <option value="7">UK — 869 MHz</option>
+                                </select>
+                            </div>
+
+                            <div style="margin-top:12px; margin-bottom:6px; font-weight:bold; font-size:13px; color:#555;">Alarm &amp; Safety</div>
+
+                            <!-- Alarm Level -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Alarm Level</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFAlarm">
+                                    <option value="0">None</option>
+                                    <option value="1">Distance-based</option>
+                                    <option value="2">Vector (recommended)</option>
+                                    <option value="3">FLARM-compatible</option>
+                                </select>
+                            </div>
+
+                            <!-- Relay Mode -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Relay Mode</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFRelay">
+                                    <option value="0">Off</option>
+                                    <option value="1">When landed (opt-in)</option>
+                                    <option value="2">All traffic</option>
+                                    <option value="3">Relay only (no own TX)</option>
+                                </select>
+                            </div>
+
+                            <!-- Stealth -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Stealth Mode<br/><small>Hide from others' displays</small></label>
+                                <div class="col-xs-7">
+                                    <ui-switch ng-model="SoftRFStealth" settings-change></ui-switch>
+                                </div>
+                            </div>
+
+                            <!-- No-Track -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">No-Track<br/><small>Opt out of OGN logging</small></label>
+                                <div class="col-xs-7">
+                                    <ui-switch ng-model="SoftRFNoTrack" settings-change></ui-switch>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- End SoftRF-specific settings -->
 
                         <div class="form-group reset-flow">
                             <button class="btn btn-primary btn-block" ng-click="updateOgnTrackerConfig()">Configure Tracker</button>


### PR DESCRIPTION
## What does this PR do?

Adds full SoftRF RF configuration support to the Stratux web UI and backend for the Moshe-Braner SoftRF fork (hardware code 13). Users can view and configure protocol, alternate protocol, frequency band, TX power, alarm method, relay mode, stealth, and no-track settings directly from the Stratux settings page.

## Architecture

Uses an **atomic snapshot** approach: all PSRFS responses are buffered in `tracker.settings` and only applied to `globalSettings` once the complete set of required keys has been received from the device. This prevents partial-readback race conditions on slow or noisy serial connections.

## Changes

### main/gen_gdl90.go
- Added SoftRF settings fields to `settings` struct (Protocol, AltProtocol, Band, Alarm, Relay, TxPower, Stealth, NoTrack)
- All int fields default to -1 ("not yet read from device")
- Old-config migration: if Protocol==0 && Band==0 (invalid zero values, no prior SoftRF config), reset all to -1

### main/tracker.go
- `softRFIdentityKeys` and `softRFExtendedKeys` named lists for clear key management
- `applyIdentityToGlobalSettings()`: atomic apply of identity config once all keys received
- `applyExtendedToGlobalSettings()`: atomic apply of extended RF config; validates protocol>0 and band>0 before writing
- `softRFSettingChanged()` helper reduces repetition in `writeConfigFromSettings`
- `isConfigRead()`: checks all required keys by name (not fragile count)
- `requestTrackerConfig()`: loops over key lists including tx_power
- `onNmea`: filters query echoes (value=="?"), stores in settings map, calls both apply methods
- `writeConfigFromSettings`: guarded writes with sentinel checks; uses helper

### main/managementinterface.go
- Handlers for all SoftRF settings; guards against writing sentinel values back to globalSettings

### web/plates/js/settings.js
- SoftRF fields loaded with safe defaults when device hasn't been read yet
- `defaultSoftRFBand()` derives band from RegionSelected
- Flat `softRFCompatMap` object filters alt protocol options via `ng-show` (no DOM churn on primary change)
- SoftRF settings only included in settings payload when hardware code == 13
- `softRFConfigReady` flag tracks readback completion

### web/plates/settings.html
- Context-sensitive labels for SoftRF vs OGN hardware
- Address type 7 (Override device ID) added for SoftRF
- All 10 RF bands: EU, US, AU, NZ, RU, CN, UK, IN, IL, KR
- TX Power control (Full/Low/Off)
- P3I (PilotAware) added as primary and alternate protocol option
- Flat alt protocol options with ng-show per option
- Configure button disabled until softRFConfigReady
- Pilot name and Registration visible for SoftRF

## Testing
- Go syntax verified with gofmt on all modified .go files
- Full compile requires Linux + RTL-SDR headers (Pi target)
- Ready for hardware testing on Moshe-Braner SoftRF device

## Wire protocol reference (Moshe-Braner fork)
Protocol values: 1=OGNTP, 2=P3I, 5=FANET, 6=Legacy(FLARMv6), 7=Latest(FLARMv7), 8=ADS-L
Band values: 1=EU, 2=US, 3=AU, 4=NZ, 5=RU, 6=CN, 7=UK, 8=IN, 9=IL, 10=KR
TxPower values: 0=off, 1=low, 2=full