### PR TITLE
Add SoftRF RF protocol, band, alarm, relay, stealth and no-track settings

### DIFF
--- a/image_build/stage2/10-stratux/01-run.sh
+++ b/image_build/stage2/10-stratux/01-run.sh
@@ -45,13 +45,28 @@ on_chroot << EOF
     pip install --break-system-packages esptool
 EOF
 
-# install bluez 5.79 version shipping with current RPiOS (5.66) is buggy in peripheral mode..
-BLUEZ_DEB="bluez_5.79-1_arm64.deb"
+# install bluez 5.87 to fix BLE advertising issues
+# BlueZ 5.79 had limitations, 5.87 provides better BLE support
+BLUEZ_VERSION="5.87"
 on_chroot << EOF
     cd /tmp
-    wget https://github.com/stratux/bluez/releases/download/v1.0/${BLUEZ_DEB}
-    dpkg -i ${BLUEZ_DEB}
-    rm ${BLUEZ_DEB}
+    
+    # Install build dependencies
+    apt install -y build-essential libdbus-1-dev libglib2.0-dev libudev-dev libical-dev libreadline-dev
+    
+    # Clone, build, and install BlueZ 5.87
+    git clone --depth 1 --branch ${BLUEZ_VERSION} https://github.com/bluez/bluez.git bluez-src
+    cd bluez-src
+    ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-library
+    make -j$(nproc)
+    make install
+    
+    # Cleanup
+    cd ..
+    rm -rf bluez-src
+    
+    # Remove build dependencies to save space
+    apt autoremove -y build-essential
 EOF
 
 LIBRTLSDR_DEB="librtlsdr0_2.0.2-2_arm64.deb"

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1244,6 +1244,16 @@ type settings struct {
 	OGNReg               string
 	OGNTxPower           int
 
+	// SoftRF-specific settings (Moshe-Braner fork)
+	SoftRFProtocol       int            // 1=OGNTP, 2=P3I, 5=FANET, 6=Legacy, 7=Latest, 8=ADS-L (-1 while unread)
+	SoftRFAltProtocol    int            // 0=none, or a valid secondary protocol value (-1 while unread)
+	SoftRFBand           int            // 1=EU, 2=US, 3=AU, 4=NZ, 5=RU, 6=CN, 7=UK, 8=IN, 9=IL, 10=KR (-1 while unread)
+	SoftRFAlarm          int            // 0=none, 1=distance, 2=vector, 3=FLARM (-1 while unread)
+	SoftRFRelay          int            // 0=off, 1=landed, 2=all, 3=relay-only (-1 while unread)
+	SoftRFTxPower        int            // 0=off, 1=low, 2=full (-1 while unread)
+	SoftRFStealth        bool
+	SoftRFNoTrack        bool
+
 	PWMDutyMin           int
 
 	// manual GPS config  (versus autodetect)
@@ -1362,6 +1372,14 @@ func defaultSettings() {
 	globalSettings.DeveloperMode = false
 	globalSettings.StaticIps = make([]string, 0)
 	globalSettings.NoSleep = false
+
+	// SoftRF defaults: -1 means "not yet read from device"
+	globalSettings.SoftRFProtocol = -1
+	globalSettings.SoftRFAltProtocol = -1
+	globalSettings.SoftRFBand = -1
+	globalSettings.SoftRFAlarm = -1
+	globalSettings.SoftRFRelay = -1
+	globalSettings.SoftRFTxPower = -1
 	globalSettings.EstimateBearinglessDist = false
 
 	globalSettings.WiFiChannel = 1

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1677,6 +1677,9 @@ func gracefulShutdown() {
 	pingKill()
 	pongKill()
 
+	// Shut down SoftRF subprocess.
+	softRFShutdown()
+
 	// Shut down data logging.
 	if dataLogStarted {
 		closeDataLog()

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -74,11 +74,10 @@ const (
 	MSGTYPE_BASIC_REPORT = 0x1E
 	MSGTYPE_LONG_REPORT  = 0x1F
 
-	MSGCLASS_UAT    = 0
-	MSGCLASS_ES     = 1
-	MSGCLASS_OGN    = 2
-	MSGCLASS_AIS    = 3
-	MSGCLASS_SOFTRF = 4
+	MSGCLASS_UAT   = 0
+	MSGCLASS_ES    = 1
+	MSGCLASS_OGN   = 2
+	MSGCLASS_AIS   = 3
 
 	LON_LAT_RESOLUTION = float32(180.0 / 8388608.0)
 	TRACK_RESOLUTION   = float32(360.0 / 256.0)
@@ -876,7 +875,6 @@ func updateMessageStats() {
 	ES_messages_last_minute := uint(0)
 	OGN_messages_last_minute := uint(0)
 	AIS_messages_last_minute := uint(0)
-	SoftRF_messages_last_minute := uint(0)
 
 	// Clear out ADSBTowers stats.
 	for t, tinf := range ADSBTowers {
@@ -917,8 +915,6 @@ func updateMessageStats() {
 				OGN_messages_last_minute++
 			} else if msgLog[i].MessageClass == MSGCLASS_AIS {
 				AIS_messages_last_minute++
-			} else if msgLog[i].MessageClass == MSGCLASS_SOFTRF {
-				SoftRF_messages_last_minute++
 			}
 		}
 	}
@@ -927,7 +923,6 @@ func updateMessageStats() {
 	globalStatus.ES_messages_last_minute = ES_messages_last_minute
 	globalStatus.OGN_messages_last_minute = OGN_messages_last_minute
 	globalStatus.AIS_messages_last_minute = AIS_messages_last_minute
-	globalStatus.SoftRF_messages_last_minute = SoftRF_messages_last_minute
 
 	// Update "max messages/min" counters.
 	if globalStatus.UAT_messages_max < UAT_messages_last_minute {
@@ -942,10 +937,6 @@ func updateMessageStats() {
 	if globalStatus.AIS_messages_max < AIS_messages_last_minute {
 		globalStatus.AIS_messages_max = AIS_messages_last_minute
 	}
-	if globalStatus.SoftRF_messages_max < SoftRF_messages_last_minute {
-		globalStatus.SoftRF_messages_max = SoftRF_messages_last_minute
-	}
-	globalStatus.SoftRF_messages_total += uint64(SoftRF_messages_last_minute)
 
 	// Update average signal strength over last minute for all ADSB towers.
 	for t, tinf := range ADSBTowers {
@@ -1296,9 +1287,6 @@ type status struct {
 	AIS_messages_max                           uint
 	AIS_messages_total                         uint64
 	AIS_connected                              bool
-	SoftRF_messages_last_minute               uint
-	SoftRF_messages_max                       uint
-	SoftRF_messages_total                     uint64
 	UAT_traffic_targets_tracking               uint16
 	ES_traffic_targets_tracking                uint16
 	Ping_connected                             bool

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1326,6 +1326,10 @@ type status struct {
 	OGN_gain_db                                float32
 	SoftRF_rx_packets                          uint32
 	SoftRF_tx_packets                          uint32
+	SoftRF_rx_FLARM_latest                     uint32
+	SoftRF_rx_FLARM_legacy                     uint32
+	SoftRF_rx_ADSL                             uint32
+	SoftRF_rx_other                            uint32
 	OGN_tx_enabled                             bool // If ogn-rx-eu uses a local tx module for transmission
 
 	OGNPrevRandomAddr                          string    // when OGN is in random stealth mode, it's ID changes randomly - keep the previous one so we can filter properly

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1426,6 +1426,26 @@ func readSettings() {
 		return
 	}
 	log.Printf("read in settings.\n")
+
+	// SoftRF settings: 0 is not a valid value for Protocol, Band, or TxPower,
+	// so if they are 0 after loading an old config file, reset to -1 (unread).
+	if globalSettings.SoftRFProtocol == 0 {
+		globalSettings.SoftRFProtocol = -1
+	}
+	if globalSettings.SoftRFBand == 0 {
+		globalSettings.SoftRFBand = -1
+	}
+	if globalSettings.SoftRFTxPower == 0 {
+		globalSettings.SoftRFTxPower = -1
+	}
+	// AltProtocol, Alarm, and Relay: 0 is valid (none/off), but we need a way
+	// to distinguish "not yet read" from "intentionally set to 0". Use -1 only
+	// if Protocol is also unread, meaning no SoftRF config has ever been saved.
+	if globalSettings.SoftRFProtocol == -1 {
+		globalSettings.SoftRFAltProtocol = -1
+		globalSettings.SoftRFAlarm = -1
+		globalSettings.SoftRFRelay = -1
+	}
 }
 
 func addSystemError(err error) {

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -74,10 +74,11 @@ const (
 	MSGTYPE_BASIC_REPORT = 0x1E
 	MSGTYPE_LONG_REPORT  = 0x1F
 
-	MSGCLASS_UAT   = 0
-	MSGCLASS_ES    = 1
-	MSGCLASS_OGN   = 2
-	MSGCLASS_AIS   = 3
+	MSGCLASS_UAT    = 0
+	MSGCLASS_ES     = 1
+	MSGCLASS_OGN    = 2
+	MSGCLASS_AIS    = 3
+	MSGCLASS_SOFTRF = 4
 
 	LON_LAT_RESOLUTION = float32(180.0 / 8388608.0)
 	TRACK_RESOLUTION   = float32(360.0 / 256.0)
@@ -875,6 +876,7 @@ func updateMessageStats() {
 	ES_messages_last_minute := uint(0)
 	OGN_messages_last_minute := uint(0)
 	AIS_messages_last_minute := uint(0)
+	SoftRF_messages_last_minute := uint(0)
 
 	// Clear out ADSBTowers stats.
 	for t, tinf := range ADSBTowers {
@@ -915,6 +917,8 @@ func updateMessageStats() {
 				OGN_messages_last_minute++
 			} else if msgLog[i].MessageClass == MSGCLASS_AIS {
 				AIS_messages_last_minute++
+			} else if msgLog[i].MessageClass == MSGCLASS_SOFTRF {
+				SoftRF_messages_last_minute++
 			}
 		}
 	}
@@ -923,6 +927,7 @@ func updateMessageStats() {
 	globalStatus.ES_messages_last_minute = ES_messages_last_minute
 	globalStatus.OGN_messages_last_minute = OGN_messages_last_minute
 	globalStatus.AIS_messages_last_minute = AIS_messages_last_minute
+	globalStatus.SoftRF_messages_last_minute = SoftRF_messages_last_minute
 
 	// Update "max messages/min" counters.
 	if globalStatus.UAT_messages_max < UAT_messages_last_minute {
@@ -937,6 +942,10 @@ func updateMessageStats() {
 	if globalStatus.AIS_messages_max < AIS_messages_last_minute {
 		globalStatus.AIS_messages_max = AIS_messages_last_minute
 	}
+	if globalStatus.SoftRF_messages_max < SoftRF_messages_last_minute {
+		globalStatus.SoftRF_messages_max = SoftRF_messages_last_minute
+	}
+	globalStatus.SoftRF_messages_total += uint64(SoftRF_messages_last_minute)
 
 	// Update average signal strength over last minute for all ADSB towers.
 	for t, tinf := range ADSBTowers {
@@ -1287,6 +1296,9 @@ type status struct {
 	AIS_messages_max                           uint
 	AIS_messages_total                         uint64
 	AIS_connected                              bool
+	SoftRF_messages_last_minute               uint
+	SoftRF_messages_max                       uint
+	SoftRF_messages_total                     uint64
 	UAT_traffic_targets_tracking               uint16
 	ES_traffic_targets_tracking                uint16
 	Ping_connected                             bool

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1324,6 +1324,8 @@ type status struct {
 	NightMode                                  bool // For turning off LEDs.
 	OGN_noise_db                               float32
 	OGN_gain_db                                float32
+	SoftRF_rx_packets                          uint32
+	SoftRF_tx_packets                          uint32
 	OGN_tx_enabled                             bool // If ogn-rx-eu uses a local tx module for transmission
 
 	OGNPrevRandomAddr                          string    // when OGN is in random stealth mode, it's ID changes randomly - keep the previous one so we can filter properly

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1253,6 +1253,7 @@ type settings struct {
 	SoftRFTxPower        int            // 0=off, 1=low, 2=full (-1 while unread)
 	SoftRFStealth        bool
 	SoftRFNoTrack        bool
+	SoftRFEnabled        bool           // enable SoftRF-MB HAT subprocess
 
 	PWMDutyMin           int
 

--- a/main/gps.go
+++ b/main/gps.go
@@ -1129,6 +1129,7 @@ func processNMEALineLow(l string, fakeGpsTimeToCurr bool) (sentenceUsed bool) {
 		return false
 	}
 	ognPublishNmea(l)
+	softRFPublishNmea(l)
 	x := strings.Split(l_valid, ",")
 
 	mySituation.GPSLastValidNMEAMessageTime = stratuxClock.Time

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -581,6 +581,48 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 					case "OGNTxPower":
 						globalSettings.OGNTxPower = int(val.(float64))
 						reconfigureTracker = true
+					case "SoftRFProtocol":
+						v := int(val.(float64))
+						if v > 0 {
+							globalSettings.SoftRFProtocol = v
+						}
+						reconfigureTracker = true
+					case "SoftRFAltProtocol":
+						v := int(val.(float64))
+						if v >= 0 {
+							globalSettings.SoftRFAltProtocol = v
+						}
+						reconfigureTracker = true
+					case "SoftRFBand":
+						v := int(val.(float64))
+						if v > 0 {
+							globalSettings.SoftRFBand = v
+						}
+						reconfigureTracker = true
+					case "SoftRFAlarm":
+						v := int(val.(float64))
+						if v >= 0 {
+							globalSettings.SoftRFAlarm = v
+						}
+						reconfigureTracker = true
+					case "SoftRFRelay":
+						v := int(val.(float64))
+						if v >= 0 {
+							globalSettings.SoftRFRelay = v
+						}
+						reconfigureTracker = true
+					case "SoftRFTxPower":
+						v := int(val.(float64))
+						if v >= 0 {
+							globalSettings.SoftRFTxPower = v
+						}
+						reconfigureTracker = true
+					case "SoftRFStealth":
+						globalSettings.SoftRFStealth = val.(bool)
+						reconfigureTracker = true
+					case "SoftRFNoTrack":
+						globalSettings.SoftRFNoTrack = val.(bool)
+						reconfigureTracker = true
 					case "PWMDutyMin":
 						globalSettings.PWMDutyMin = int(val.(float64))
 						reconfigureFancontrol = true

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -623,6 +623,9 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 					case "SoftRFNoTrack":
 						globalSettings.SoftRFNoTrack = val.(bool)
 						reconfigureTracker = true
+					case "SoftRFEnabled":
+						globalSettings.SoftRFEnabled = val.(bool)
+						softRFSignalRestart()
 					case "PWMDutyMin":
 						globalSettings.PWMDutyMin = int(val.(float64))
 						reconfigureFancontrol = true
@@ -635,6 +638,9 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 				applyNetworkSettings(false, false)
 				if reconfigureTracker && detectedTracker != nil {
 					writeTrackerConfigFromSettings()
+				}
+				if reconfigureTracker && globalSettings.SoftRFEnabled {
+					softRFSignalRestart()
 				}
 				if reconfigureFancontrol {
 					exec.Command("killall", "-SIGUSR1", "fancontrol").Run();

--- a/main/sensors.go
+++ b/main/sensors.go
@@ -429,6 +429,12 @@ func updateExtraLogging() {
 	logMap["GPSHorizontalAccuracy"] = mySituation.GPSHorizontalAccuracy
 	logMap["GPSLatitude"] = mySituation.GPSLatitude
 	logMap["GPSLongitude"] = mySituation.GPSLongitude
+	if !mySituation.GPSTime.IsZero() {
+		logMap["GPSTime"] = float64(mySituation.GPSTime.UTC().Unix())
+	} else {
+		logMap["GPSTime"] = 0.0
+	}
+	logMap["GPSLastFixTimeSinceMidnight"] = float64(mySituation.GPSLastFixSinceMidnightUTC)
 	logMap["GPSAltitudeMSL"] = mySituation.GPSAltitudeMSL
 	logMap["GPSFixQuality"] = float64(mySituation.GPSFixQuality)
 	logMap["BaroPressureAltitude"] = float64(mySituation.BaroPressureAltitude)

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -117,10 +117,14 @@ func writeSoftRFSettings() error {
 	}
 
 	// flr_adsl enables simultaneous FLARM Latest + ADS-L reception using a combined
-	// 2-byte syncword {0x56, 0x66}. Disabled for now: causes TX timeout and RX failure
-	// on Badge Edition (MB177) and may not be compatible with all SoftRF firmware versions.
-	// Without flr_adsl, the Pi time-slots between protocols using altprotocol switching.
+	// 2-byte syncword {0x56, 0x66}. Without flr_adsl, the SX1262 mixed protocol
+	// time-slotting is broken and reception drops to near-zero. The Pi's SoftRF binary
+	// requires flr_adsl=1 for reliable dual-protocol operation. TX still uses standard
+	// per-protocol syncwords, so non-flr_adsl devices can receive the Pi's transmissions.
 	flrAdsl := 0
+	if (protocol == 7 || altProtocol == 7) && (protocol == 8 || altProtocol == 8) {
+		flrAdsl = 1
+	}
 
 	content := fmt.Sprintf(
 		"SoftRF,1\n"+

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -212,6 +212,10 @@ func softRFListen() {
 				switch fields[0] {
 				case "$PFLAA":
 					parseFlarmPFLAA(fields)
+					var m msg
+					m.MessageClass = MSGCLASS_SOFTRF
+					m.TimeReceived = stratuxClock.Time
+					msgLogAppend(m)
 				case "$PFLAU":
 					parseFlarmPFLAU(fields)
 				}

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -1,0 +1,235 @@
+/*
+	Copyright (c) 2024 Stratux Contributors
+	Distributable under the terms of The "BSD New" License
+	that can be found in the LICENSE file, herein included
+	as part of this header.
+
+	softrf_mb.go: Integration of Moshe-Braner SoftRF HAT as a subprocess.
+	Writes /etc/softrf/settings.txt from globalSettings, launches the SoftRF
+	binary, pipes Stratux GPS NMEA into stdin, and reads $PFLAA/$PFLAU from
+	stdout into the existing FLARM traffic pipeline.
+*/
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const softRFBinaryPath = "/usr/bin/softrf"
+const softRFSettingsPath = "/etc/softrf/settings.txt"
+
+// softRFNMEAChan carries GPS NMEA sentences to the SoftRF subprocess stdin.
+var softRFNMEAChan = make(chan string, 100)
+
+// softRFRestartChan signals the subprocess manager to restart with new settings.
+var softRFRestartChan = make(chan bool, 1)
+
+// softRFPublishNmea is called from gps.go for every valid NMEA sentence.
+func softRFPublishNmea(nmea string) {
+	if !globalSettings.SoftRFEnabled {
+		return
+	}
+	if !strings.HasSuffix(nmea, "\r\n") {
+		nmea += "\r\n"
+	}
+	select {
+	case softRFNMEAChan <- nmea:
+	default: // drop if channel is full; GPS updates are frequent enough
+	}
+}
+
+// softRFSignalRestart asks the running subprocess to restart with updated settings.
+// Called from managementinterface.go when SoftRF settings change.
+func softRFSignalRestart() {
+	select {
+	case softRFRestartChan <- true:
+	default:
+	}
+}
+
+func writeSoftRFSettings() error {
+	if err := os.MkdirAll("/etc/softrf", 0755); err != nil {
+		return err
+	}
+
+	// Resolve int fields, applying defaults for unread (-1) values.
+	protocol := 7 // FLARM Latest
+	if globalSettings.SoftRFProtocol > 0 {
+		protocol = globalSettings.SoftRFProtocol
+	}
+	altProtocol := 8 // ADS-L
+	if globalSettings.SoftRFAltProtocol >= 0 {
+		altProtocol = globalSettings.SoftRFAltProtocol
+	}
+	band := 2 // US 915 MHz
+	if globalSettings.SoftRFBand > 0 {
+		band = globalSettings.SoftRFBand
+	}
+	txPower := 2 // full
+	if globalSettings.SoftRFTxPower >= 0 {
+		txPower = globalSettings.SoftRFTxPower
+	}
+	alarm := 3 // FLARM algorithm
+	if globalSettings.SoftRFAlarm >= 0 {
+		alarm = globalSettings.SoftRFAlarm
+	}
+	relay := 1 // relay landed traffic
+	if globalSettings.SoftRFRelay >= 0 {
+		relay = globalSettings.SoftRFRelay
+	}
+
+	acftType := mapAircraftType(typeMappingOgn2SoftRF, true, globalSettings.OGNAcftType)
+	if acftType < 0 {
+		acftType = 1 // glider default
+	}
+	idMethod := globalSettings.OGNAddrType
+	aircraftID := globalSettings.OGNAddr
+	if len(aircraftID) == 0 {
+		aircraftID = "000000"
+	}
+
+	stealth := 0
+	if globalSettings.SoftRFStealth {
+		stealth = 1
+	}
+	noTrack := 0
+	if globalSettings.SoftRFNoTrack {
+		noTrack = 1
+	}
+
+	content := fmt.Sprintf(
+		"SoftRF,1\n"+
+			"mode,0\n"+
+			"protocol,%d\n"+
+			"altprotocol,%d\n"+
+			"band,%d\n"+
+			"acft_type,%d\n"+
+			"id_method,%d\n"+
+			"aircraft_id,%s\n"+
+			"alarm,%d\n"+
+			"relay,%d\n"+
+			"tx_power,%d\n"+
+			"stealth,%d\n"+
+			"no_track,%d\n"+
+			"nmea_out,1\n"+   // output to stdout
+			"nmea_g,00\n"+    // no GPS sentences (Stratux has its own GPS)
+			"nmea_s,00\n"+    // no sensor sentences
+			"nmea_t,01\n"+    // traffic sentences on ($PFLAA/$PFLAU)
+			"nmea_e,00\n"+    // no tunnel
+			"nmea_d,00\n"+    // no debug sentences
+			"gdl90,0\n"+      // Stratux generates GDL90
+			"logflight,0\n",  // no flight logging
+		protocol, altProtocol, band,
+		acftType, idMethod, aircraftID,
+		alarm, relay, txPower,
+		stealth, noTrack,
+	)
+
+	return os.WriteFile(softRFSettingsPath, []byte(content), 0644)
+}
+
+func softRFListen() {
+	for {
+		if !globalSettings.SoftRFEnabled {
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		if _, err := os.Stat(softRFBinaryPath); os.IsNotExist(err) {
+			log.Printf("SoftRF HAT: binary not found at %s, waiting...", softRFBinaryPath)
+			time.Sleep(30 * time.Second)
+			continue
+		}
+
+		if err := writeSoftRFSettings(); err != nil {
+			log.Printf("SoftRF HAT: failed to write settings: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		log.Printf("SoftRF HAT: starting subprocess")
+		cmd := exec.Command(softRFBinaryPath)
+
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			log.Printf("SoftRF HAT: stdin pipe error: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			log.Printf("SoftRF HAT: stdout pipe error: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		cmd.Stderr = nil // discard SoftRF debug/info stderr
+
+		if err := cmd.Start(); err != nil {
+			log.Printf("SoftRF HAT: failed to start: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		log.Printf("SoftRF HAT: subprocess started (PID %d)", cmd.Process.Pid)
+
+		exitChan := make(chan error, 1)
+		go func() { exitChan <- cmd.Wait() }()
+
+		// Writer: forward GPS NMEA from channel to SoftRF stdin.
+		go func() {
+			for nmea := range softRFNMEAChan {
+				if _, err := fmt.Fprint(stdin, nmea); err != nil {
+					return
+				}
+			}
+		}()
+
+		// Reader: parse $PFLAA/$PFLAU from SoftRF stdout.
+		scanDone := make(chan struct{}, 1)
+		go func() {
+			defer func() { scanDone <- struct{}{} }()
+			scanner := bufio.NewScanner(stdout)
+			for scanner.Scan() {
+				line := scanner.Text()
+				if !strings.HasPrefix(line, "$PFL") {
+					continue
+				}
+				// Strip checksum suffix before splitting fields.
+				bare := line
+				if idx := strings.LastIndex(line, "*"); idx >= 0 {
+					bare = line[:idx]
+				}
+				fields := strings.Split(bare, ",")
+				if len(fields) < 2 {
+					continue
+				}
+				switch fields[0] {
+				case "$PFLAA":
+					parseFlarmPFLAA(fields)
+				case "$PFLAU":
+					parseFlarmPFLAU(fields)
+				}
+			}
+		}()
+
+		// Wait for subprocess exit or a settings-change restart signal.
+		select {
+		case err := <-exitChan:
+			log.Printf("SoftRF HAT: subprocess exited: %v", err)
+		case <-softRFRestartChan:
+			log.Printf("SoftRF HAT: restarting subprocess for settings change")
+			cmd.Process.Kill()
+			<-exitChan
+		}
+
+		stdin.Close()
+		<-scanDone
+		time.Sleep(3 * time.Second)
+	}
+}

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -105,10 +105,9 @@ func writeSoftRFSettings() error {
 		noTrack = 1
 	}
 
-	// flr_adsl enables dual FLARM Latest + ADS-L simultaneous reception using a
-	// combined syncword. As of MB179+, ADS-L uses the FLARM frequency plan on all
-	// bands (not OGN hopping), so both FLARM Latest and ADS-L share the same channel.
-	// Enable whenever FLARM Latest and ADS-L are used together.
+	// flr_adsl enables simultaneous FLARM Latest + ADS-L reception using a combined
+	// 2-byte syncword {0x56, 0x66}. SX1262 (Core1262 HF) writes both syncword bytes
+	// directly to hardware FSK registers via SetSyncWordFsk(), so this works correctly.
 	flrAdsl := 0
 	if (protocol == 7 || altProtocol == 7) && (protocol == 8 || altProtocol == 8) {
 		flrAdsl = 1
@@ -180,7 +179,12 @@ func softRFListen() {
 			time.Sleep(5 * time.Second)
 			continue
 		}
-		cmd.Stderr = nil // discard SoftRF debug/info stderr
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			log.Printf("SoftRF HAT: stderr pipe error: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
 
 		if err := cmd.Start(); err != nil {
 			log.Printf("SoftRF HAT: failed to start: %v", err)
@@ -202,13 +206,16 @@ func softRFListen() {
 		}()
 
 		// Reader: parse $PFLAA/$PFLAU from SoftRF stdout.
-		scanDone := make(chan struct{}, 1)
+		stdoutScanDone := make(chan struct{}, 1)
 		go func() {
-			defer func() { scanDone <- struct{}{} }()
+			defer func() { stdoutScanDone <- struct{}{} }()
 			scanner := bufio.NewScanner(stdout)
 			for scanner.Scan() {
 				line := scanner.Text()
 				if !strings.HasPrefix(line, "$PFL") && !strings.HasPrefix(line, "$PSRFH") {
+					if globalSettings.DEBUG && len(line) > 0 {
+						log.Printf("SoftRF HAT stdout: %s", line)
+					}
 					continue
 				}
 				// Strip checksum suffix before splitting fields.
@@ -265,6 +272,18 @@ func softRFListen() {
 			}
 		}()
 
+		stderrScanDone := make(chan struct{}, 1)
+		go func() {
+			defer func() { stderrScanDone <- struct{}{} }()
+			scanner := bufio.NewScanner(stderr)
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if len(line) > 0 {
+					log.Printf("SoftRF HAT stderr: %s", line)
+				}
+			}
+		}()
+
 		// Wait for subprocess exit or a settings-change restart signal.
 		select {
 		case err := <-exitChan:
@@ -276,7 +295,8 @@ func softRFListen() {
 		}
 
 		stdin.Close()
-		<-scanDone
+		<-stdoutScanDone
+		<-stderrScanDone
 		time.Sleep(3 * time.Second)
 	}
 }

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -117,12 +117,10 @@ func writeSoftRFSettings() error {
 	}
 
 	// flr_adsl enables simultaneous FLARM Latest + ADS-L reception using a combined
-	// 2-byte syncword {0x56, 0x66}. SX1262 (Core1262 HF) writes both syncword bytes
-	// directly to hardware FSK registers via SetSyncWordFsk(), so this works correctly.
+	// 2-byte syncword {0x56, 0x66}. Disabled for now: causes TX timeout and RX failure
+	// on Badge Edition (MB177) and may not be compatible with all SoftRF firmware versions.
+	// Without flr_adsl, the Pi time-slots between protocols using altprotocol switching.
 	flrAdsl := 0
-	if (protocol == 7 || altProtocol == 7) && (protocol == 8 || altProtocol == 8) {
-		flrAdsl = 1
-	}
 
 	content := fmt.Sprintf(
 		"SoftRF,1\n"+

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -197,7 +198,7 @@ func softRFListen() {
 			scanner := bufio.NewScanner(stdout)
 			for scanner.Scan() {
 				line := scanner.Text()
-				if !strings.HasPrefix(line, "$PFL") {
+				if !strings.HasPrefix(line, "$PFL") && !strings.HasPrefix(line, "$PSRFH") {
 					continue
 				}
 				// Strip checksum suffix before splitting fields.
@@ -218,6 +219,16 @@ func softRFListen() {
 					msgLogAppend(m)
 				case "$PFLAU":
 					parseFlarmPFLAU(fields)
+				case "$PSRFH":
+					// $PSRFH,addr,proto,altproto,millis,voltage,heap,rx_pkts,tx_pkts,nacft,maxrssi
+					if len(fields) >= 9 {
+						if rx, err := strconv.ParseUint(fields[7], 10, 32); err == nil {
+							globalStatus.SoftRF_rx_packets = uint32(rx)
+						}
+						if tx, err := strconv.ParseUint(fields[8], 10, 32); err == nil {
+							globalStatus.SoftRF_tx_packets = uint32(tx)
+						}
+					}
 				}
 			}
 		}()

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -213,7 +213,7 @@ func softRFListen() {
 				case "$PFLAA":
 					parseFlarmPFLAA(fields)
 					var m msg
-					m.MessageClass = MSGCLASS_SOFTRF
+					m.MessageClass = MSGCLASS_OGN
 					m.TimeReceived = stratuxClock.Time
 					msgLogAppend(m)
 				case "$PFLAU":

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -213,6 +213,28 @@ func softRFListen() {
 				switch fields[0] {
 				case "$PFLAA":
 					parseFlarmPFLAA(fields)
+					// Count by protocol: the ID field (index 6) has format ADDR!PREFIX_ADDR
+					// where PREFIX is "FLR" (FLARM Latest), "FLO" (FLARM Legacy), "ADL" (ADS-L), etc.
+					if len(fields) > 6 {
+						id := fields[6]
+						if bang := strings.Index(id, "!"); bang >= 0 {
+							rest := id[bang+1:]
+							prefix := rest
+							if under := strings.Index(rest, "_"); under >= 0 {
+								prefix = rest[:under]
+							}
+							switch prefix {
+							case "FLR", "LND": // FLARM Latest (LND = landed-out Latest)
+								globalStatus.SoftRF_rx_FLARM_latest++
+							case "FLO": // FLARM Legacy
+								globalStatus.SoftRF_rx_FLARM_legacy++
+							case "ADL": // ADS-L
+								globalStatus.SoftRF_rx_ADSL++
+							default:
+								globalStatus.SoftRF_rx_other++
+							}
+						}
+					}
 					var m msg
 					m.MessageClass = MSGCLASS_OGN
 					m.TimeReceived = stratuxClock.Time

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -105,8 +105,10 @@ func writeSoftRFSettings() error {
 		noTrack = 1
 	}
 
-	// Enable dual FLARM+ADS-L simultaneous reception when both are configured.
-	// Without flr_adsl=1, ADS-L is only received in rare 8-second alt-protocol slots.
+	// flr_adsl enables dual FLARM Latest + ADS-L simultaneous reception using a
+	// combined syncword. As of MB179+, ADS-L uses the FLARM frequency plan on all
+	// bands (not OGN hopping), so both FLARM Latest and ADS-L share the same channel.
+	// Enable whenever FLARM Latest and ADS-L are used together.
 	flrAdsl := 0
 	if (protocol == 7 || altProtocol == 7) && (protocol == 8 || altProtocol == 8) {
 		flrAdsl = 1

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -32,6 +32,9 @@ var softRFNMEAChan = make(chan string, 100)
 // softRFRestartChan signals the subprocess manager to restart with new settings.
 var softRFRestartChan = make(chan bool, 1)
 
+// softRFShutdownChan signals the subprocess manager to kill the subprocess and exit.
+var softRFShutdownChan = make(chan bool, 1)
+
 // softRFPublishNmea is called from gps.go for every valid NMEA sentence.
 func softRFPublishNmea(nmea string) {
 	if !globalSettings.SoftRFEnabled {
@@ -51,6 +54,14 @@ func softRFPublishNmea(nmea string) {
 func softRFSignalRestart() {
 	select {
 	case softRFRestartChan <- true:
+	default:
+	}
+}
+
+// softRFShutdown kills the SoftRF subprocess during graceful shutdown.
+func softRFShutdown() {
+	select {
+	case softRFShutdownChan <- true:
 	default:
 	}
 }
@@ -292,6 +303,14 @@ func softRFListen() {
 			log.Printf("SoftRF HAT: restarting subprocess for settings change")
 			cmd.Process.Kill()
 			<-exitChan
+		case <-softRFShutdownChan:
+			log.Printf("SoftRF HAT: shutting down subprocess")
+			cmd.Process.Kill()
+			<-exitChan
+			stdin.Close()
+			<-stdoutScanDone
+			<-stderrScanDone
+			return
 		}
 
 		stdin.Close()

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -105,6 +105,13 @@ func writeSoftRFSettings() error {
 		noTrack = 1
 	}
 
+	// Enable dual FLARM+ADS-L simultaneous reception when both are configured.
+	// Without flr_adsl=1, ADS-L is only received in rare 8-second alt-protocol slots.
+	flrAdsl := 0
+	if (protocol == 7 || altProtocol == 7) && (protocol == 8 || altProtocol == 8) {
+		flrAdsl = 1
+	}
+
 	content := fmt.Sprintf(
 		"SoftRF,1\n"+
 			"mode,0\n"+
@@ -119,6 +126,7 @@ func writeSoftRFSettings() error {
 			"tx_power,%d\n"+
 			"stealth,%d\n"+
 			"no_track,%d\n"+
+			"flr_adsl,%d\n"+  // dual FLARM Latest + ADS-L simultaneous reception
 			"nmea_out,1\n"+   // output to stdout
 			"nmea_g,00\n"+    // no GPS sentences (Stratux has its own GPS)
 			"nmea_s,00\n"+    // no sensor sentences
@@ -130,7 +138,7 @@ func writeSoftRFSettings() error {
 		protocol, altProtocol, band,
 		acftType, idMethod, aircraftID,
 		alarm, relay, txPower,
-		stealth, noTrack,
+		stealth, noTrack, flrAdsl,
 	)
 
 	return os.WriteFile(softRFSettingsPath, []byte(content), 0644)

--- a/main/softrf_mb.go
+++ b/main/softrf_mb.go
@@ -36,9 +36,22 @@ var softRFRestartChan = make(chan bool, 1)
 var softRFShutdownChan = make(chan bool, 1)
 
 // softRFPublishNmea is called from gps.go for every valid NMEA sentence.
+// Only GGA and RMC sentences are forwarded — SoftRF's RPi_PickGNSSFix() needs
+// both within 600ms to sync its internal clock, and flooding stdin with all
+// NMEA types causes the GGA/RMC pair to arrive in different read cycles,
+// resulting in a drifting RF_time that breaks FLARM decryption.
 func softRFPublishNmea(nmea string) {
 	if !globalSettings.SoftRFEnabled {
 		return
+	}
+	// Only forward GGA and RMC — the two sentences needed for GNSS time sync.
+	if len(nmea) > 6 {
+		talker := nmea[1:3] // e.g. "GP", "GN", "GL"
+		_ = talker
+		sentenceType := nmea[3:6]
+		if sentenceType != "GGA" && sentenceType != "RMC" {
+			return
+		}
 	}
 	if !strings.HasSuffix(nmea, "\r\n") {
 		nmea += "\r\n"

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -347,6 +347,9 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 	// See output of $PSRFS,0,?*4B
 	if nmea[0] == "PSRFS" {
 		key, value := nmea[2], nmea[3]
+		if value == "?" {
+			return true // ignore query echoes
+		}
 		log.Printf("Received SoftRF config %s=%s", key, value)
 		tracker.settings[key] = value
 		if key == "acft_type" {

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -351,7 +351,10 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 			return true // ignore query echoes
 		}
 		log.Printf("Received SoftRF config %s=%s", key, value)
+		wasConfigRead := tracker.isConfigRead()
 		tracker.settings[key] = value
+
+		// Identity fields: always update globalSettings from device
 		if key == "acft_type" {
 			acType, _ := strconv.Atoi(value)
 			acType = mapAircraftType(typeMappingOgn2SoftRF, false, acType)
@@ -360,23 +363,37 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 			globalSettings.OGNAddrType, _ = strconv.Atoi(value)
 		} else if key == "aircraft_id" {
 			globalSettings.OGNAddr = value
-		} else if key == "protocol" {
-			globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
-		} else if key == "altprotocol" {
-			globalSettings.SoftRFAltProtocol, _ = strconv.Atoi(value)
-		} else if key == "band" {
-			globalSettings.SoftRFBand, _ = strconv.Atoi(value)
-		} else if key == "alarm" {
-			globalSettings.SoftRFAlarm, _ = strconv.Atoi(value)
-		} else if key == "relay" {
-			globalSettings.SoftRFRelay, _ = strconv.Atoi(value)
-		} else if key == "tx_power" {
-			globalSettings.SoftRFTxPower, _ = strconv.Atoi(value)
-		} else if key == "stealth" {
-			globalSettings.SoftRFStealth = value == "1"
-		} else if key == "no_track" {
-			globalSettings.SoftRFNoTrack = value == "1"
 		}
+
+		// SoftRF-specific fields: only update globalSettings on initial read
+		// (when Protocol is still -1). After that, globalSettings reflects the
+		// user's desired state, and tracker.settings tracks the device state.
+		if globalSettings.SoftRFProtocol == -1 {
+			if key == "protocol" {
+				globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
+			} else if key == "altprotocol" {
+				globalSettings.SoftRFAltProtocol, _ = strconv.Atoi(value)
+			} else if key == "band" {
+				globalSettings.SoftRFBand, _ = strconv.Atoi(value)
+			} else if key == "alarm" {
+				globalSettings.SoftRFAlarm, _ = strconv.Atoi(value)
+			} else if key == "relay" {
+				globalSettings.SoftRFRelay, _ = strconv.Atoi(value)
+			} else if key == "tx_power" {
+				globalSettings.SoftRFTxPower, _ = strconv.Atoi(value)
+			} else if key == "stealth" {
+				globalSettings.SoftRFStealth = value == "1"
+			} else if key == "no_track" {
+				globalSettings.SoftRFNoTrack = value == "1"
+			}
+		}
+
+		// After config is fully read for the first time (or after reconnect),
+		// apply any pending user changes that differ from device state.
+		if !wasConfigRead && tracker.isConfigRead() {
+			writeTrackerConfigFromSettings()
+		}
+
 		return true
 	}
 

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -357,6 +357,22 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 			globalSettings.OGNAddrType, _ = strconv.Atoi(value)
 		} else if key == "aircraft_id" {
 			globalSettings.OGNAddr = value
+		} else if key == "protocol" {
+			globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
+		} else if key == "altprotocol" {
+			globalSettings.SoftRFAltProtocol, _ = strconv.Atoi(value)
+		} else if key == "band" {
+			globalSettings.SoftRFBand, _ = strconv.Atoi(value)
+		} else if key == "alarm" {
+			globalSettings.SoftRFAlarm, _ = strconv.Atoi(value)
+		} else if key == "relay" {
+			globalSettings.SoftRFRelay, _ = strconv.Atoi(value)
+		} else if key == "tx_power" {
+			globalSettings.SoftRFTxPower, _ = strconv.Atoi(value)
+		} else if key == "stealth" {
+			globalSettings.SoftRFStealth = value == "1"
+		} else if key == "no_track" {
+			globalSettings.SoftRFNoTrack = value == "1"
 		}
 		return true
 	}
@@ -377,7 +393,7 @@ func (tracker *SoftRF) isDetected() bool {
 }
 
 func (tracker *SoftRF) isConfigRead() bool {
-	return len(tracker.settings) >= 5 // need at least or 5 main settings: acft type, id method and id, as well as nmea1/2 mode
+	return len(tracker.settings) >= 12 // need identity (3) + nmea gates (2) + rf settings (protocol, altprotocol, band, tx_power, alarm, relay, stealth)
 }
 
 func (tracker *SoftRF) writeReadDelay() time.Duration {
@@ -408,11 +424,22 @@ func (tracker *SoftRF) writeInitialConfig(serialPort *serial.Port) bool {
 }
 
 func (tracker *SoftRF) requestTrackerConfig(serialPort *serial.Port) {
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,nmea_g,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,nmea2_g,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,acft_type,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,aircraft_id,?") + "\r\n"))
-	serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0,id_method,?") + "\r\n"))
+	keys := []string{
+		"nmea_g", "nmea2_g",
+		"acft_type", "aircraft_id", "id_method",
+		"protocol", "altprotocol", "band", "alarm", "relay",
+		"tx_power", "stealth", "no_track",
+	}
+	for _, key := range keys {
+		serialPort.Write([]byte(appendNmeaChecksum("$PSRFS,0," + key + ",?") + "\r\n"))
+	}
+}
+
+func (tracker *SoftRF) softRFSettingChanged(key string, desired string) bool {
+	if s, ok := tracker.settings[key]; !ok || s != desired {
+		return true
+	}
+	return false
 }
 
 func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
@@ -426,14 +453,69 @@ func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
 
 	var messages []string
 
-	if s, ok := tracker.settings["acft_type"]; !ok || acType != s {
+	if tracker.softRFSettingChanged("acft_type", acType) {
 		messages = append(messages, appendNmeaChecksum("$PSRFS,0,acft_type," + acType) + "\r\n")
 	}
-	if s, ok := tracker.settings["id_method"]; !ok || addrType != s {
+	if tracker.softRFSettingChanged("id_method", addrType) {
 		messages = append(messages, appendNmeaChecksum("$PSRFS,0,id_method," + addrType) + "\r\n")
 	}
-	if s, ok := tracker.settings["aircraft_id"]; !ok || addr != s {
+	if tracker.softRFSettingChanged("aircraft_id", addr) {
 		messages = append(messages, appendNmeaChecksum("$PSRFS,0,aircraft_id," + addr) + "\r\n")
+	}
+
+	// SoftRF-specific settings: only send if they have been read from the device (>= 0 or -1 means unread)
+	if globalSettings.SoftRFProtocol > 0 {
+		desired := strconv.Itoa(globalSettings.SoftRFProtocol)
+		if tracker.softRFSettingChanged("protocol", desired) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,protocol," + desired) + "\r\n")
+		}
+	}
+	if globalSettings.SoftRFAltProtocol >= 0 {
+		desired := strconv.Itoa(globalSettings.SoftRFAltProtocol)
+		if tracker.softRFSettingChanged("altprotocol", desired) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,altprotocol," + desired) + "\r\n")
+		}
+	}
+	if globalSettings.SoftRFBand > 0 {
+		desired := strconv.Itoa(globalSettings.SoftRFBand)
+		if tracker.softRFSettingChanged("band", desired) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,band," + desired) + "\r\n")
+		}
+	}
+	if globalSettings.SoftRFAlarm >= 0 {
+		desired := strconv.Itoa(globalSettings.SoftRFAlarm)
+		if tracker.softRFSettingChanged("alarm", desired) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,alarm," + desired) + "\r\n")
+		}
+	}
+	if globalSettings.SoftRFRelay >= 0 {
+		desired := strconv.Itoa(globalSettings.SoftRFRelay)
+		if tracker.softRFSettingChanged("relay", desired) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,relay," + desired) + "\r\n")
+		}
+	}
+	if globalSettings.SoftRFTxPower >= 0 {
+		desired := strconv.Itoa(globalSettings.SoftRFTxPower)
+		if tracker.softRFSettingChanged("tx_power", desired) {
+			messages = append(messages, appendNmeaChecksum("$PSRFS,0,tx_power," + desired) + "\r\n")
+		}
+	}
+
+	// Boolean settings: always send if different from device
+	stealthDesired := "0"
+	if globalSettings.SoftRFStealth {
+		stealthDesired = "1"
+	}
+	if tracker.softRFSettingChanged("stealth", stealthDesired) {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,stealth," + stealthDesired) + "\r\n")
+	}
+
+	noTrackDesired := "0"
+	if globalSettings.SoftRFNoTrack {
+		noTrackDesired = "1"
+	}
+	if tracker.softRFSettingChanged("no_track", noTrackDesired) {
+		messages = append(messages, appendNmeaChecksum("$PSRFS,0,no_track," + noTrackDesired) + "\r\n")
 	}
 
 	for _, msg := range messages {
@@ -442,9 +524,9 @@ func (tracker *SoftRF) writeConfigFromSettings(serialPort *serial.Port) bool {
 	}
 
 	if len(messages) > 0 {
-		serialPort.Write([]byte(appendNmeaChecksum("$PSRFC,SAV") + "\r\n")) // Finally reboot
+		serialPort.Write([]byte(appendNmeaChecksum("$PSRFC,SAV") + "\r\n")) // Save and reboot
 	}
-	
+
 	return len(messages) > 0
 }
 

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -351,10 +351,7 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 			return true // ignore query echoes
 		}
 		log.Printf("Received SoftRF config %s=%s", key, value)
-		wasConfigRead := tracker.isConfigRead()
 		tracker.settings[key] = value
-
-		// Identity fields: always update globalSettings from device
 		if key == "acft_type" {
 			acType, _ := strconv.Atoi(value)
 			acType = mapAircraftType(typeMappingOgn2SoftRF, false, acType)
@@ -363,43 +360,23 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 			globalSettings.OGNAddrType, _ = strconv.Atoi(value)
 		} else if key == "aircraft_id" {
 			globalSettings.OGNAddr = value
+		} else if key == "protocol" {
+			globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
+		} else if key == "altprotocol" {
+			globalSettings.SoftRFAltProtocol, _ = strconv.Atoi(value)
+		} else if key == "band" {
+			globalSettings.SoftRFBand, _ = strconv.Atoi(value)
+		} else if key == "alarm" {
+			globalSettings.SoftRFAlarm, _ = strconv.Atoi(value)
+		} else if key == "relay" {
+			globalSettings.SoftRFRelay, _ = strconv.Atoi(value)
+		} else if key == "tx_power" {
+			globalSettings.SoftRFTxPower, _ = strconv.Atoi(value)
+		} else if key == "stealth" {
+			globalSettings.SoftRFStealth = value == "1"
+		} else if key == "no_track" {
+			globalSettings.SoftRFNoTrack = value == "1"
 		}
-
-		// SoftRF-specific fields: only update globalSettings on initial read
-		// (when Protocol is still -1). After that, globalSettings reflects the
-		// user's desired state, and tracker.settings tracks the device state.
-		if globalSettings.SoftRFProtocol == -1 {
-			if key == "protocol" {
-				globalSettings.SoftRFProtocol, _ = strconv.Atoi(value)
-			} else if key == "altprotocol" {
-				globalSettings.SoftRFAltProtocol, _ = strconv.Atoi(value)
-			} else if key == "band" {
-				globalSettings.SoftRFBand, _ = strconv.Atoi(value)
-			} else if key == "alarm" {
-				globalSettings.SoftRFAlarm, _ = strconv.Atoi(value)
-			} else if key == "relay" {
-				globalSettings.SoftRFRelay, _ = strconv.Atoi(value)
-			} else if key == "tx_power" {
-				globalSettings.SoftRFTxPower, _ = strconv.Atoi(value)
-			} else if key == "stealth" {
-				globalSettings.SoftRFStealth = value == "1"
-			} else if key == "no_track" {
-				globalSettings.SoftRFNoTrack = value == "1"
-			}
-		}
-
-		// After config is fully read (or after reconnect), apply any pending
-		// user changes that differ from device state. Defer to let the device
-		// finish sending readback responses before we write.
-		if !wasConfigRead && tracker.isConfigRead() {
-			go func() {
-				time.Sleep(2 * time.Second)
-				if tracker == detectedTracker {
-					writeTrackerConfigFromSettings()
-				}
-			}()
-		}
-
 		return true
 	}
 

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -388,10 +388,16 @@ func (tracker *SoftRF) onNmea(serialPort *serial.Port, nmea []string) bool {
 			}
 		}
 
-		// After config is fully read for the first time (or after reconnect),
-		// apply any pending user changes that differ from device state.
+		// After config is fully read (or after reconnect), apply any pending
+		// user changes that differ from device state. Defer to let the device
+		// finish sending readback responses before we write.
 		if !wasConfigRead && tracker.isConfigRead() {
-			writeTrackerConfigFromSettings()
+			go func() {
+				time.Sleep(2 * time.Second)
+				if tracker == detectedTracker {
+					writeTrackerConfigFromSettings()
+				}
+			}()
 		}
 
 		return true

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -1728,6 +1728,7 @@ func initTraffic(isTraceReplayMode bool) {
 	if !isTraceReplayMode {
 		go esListen()
 		go ognListen()
+		go softRFListen()
 		go aprsListen()
 		go aisListen()
 	}

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -152,7 +152,8 @@ app.controller('MainCtrl', function ($scope, $http) {
 		2: '#FF8C00',      // UAT
 		4: 'green',          // OGN
 		5: '#0077be',         // AIS
-		6: 'darkkhaki'     // UAT bar color
+		6: 'darkkhaki',    // UAT bar color
+		7: 'darkorchid'    // SoftRF HAT
 	}
 
 	const getTrafficSourceColor = (source) => {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -152,8 +152,7 @@ app.controller('MainCtrl', function ($scope, $http) {
 		2: '#FF8C00',      // UAT
 		4: 'green',          // OGN
 		5: '#0077be',         // AIS
-		6: 'darkkhaki',    // UAT bar color
-		7: 'darkorchid'    // SoftRF HAT
+		6: 'darkkhaki'     // UAT bar color
 	}
 
 	const getTrafficSourceColor = (source) => {

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -754,8 +754,8 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			"OGNTxPower": $scope.OGNTxPower
 		};
 
-		// Include SoftRF-specific settings if a SoftRF device is connected
-		if ($scope.gpsHardwareCode == 13) {
+		// Include SoftRF-specific settings if a SoftRF device is connected or HAT is enabled
+		if ($scope.gpsHardwareCode == 13 || $scope.SoftRFEnabled) {
 			newsettings["SoftRFProtocol"] = parseInt($scope.SoftRFProtocol);
 			newsettings["SoftRFAltProtocol"] = parseInt($scope.SoftRFAltProtocol);
 			newsettings["SoftRFBand"] = parseInt($scope.SoftRFBand);

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -345,6 +345,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.OGNTxPower = settings.OGNTxPower;
 
 		// SoftRF-specific settings
+		$scope.SoftRFEnabled = settings.SoftRFEnabled;
 		$scope.SoftRFProtocol = (settings.SoftRFProtocol >= 0) ? settings.SoftRFProtocol.toString() : "7";
 		$scope.SoftRFAltProtocol = (settings.SoftRFAltProtocol >= 0) ? settings.SoftRFAltProtocol.toString() : "0";
 		$scope.SoftRFBand = (settings.SoftRFBand >= 0) ? settings.SoftRFBand.toString() : "2";

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -346,6 +346,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 		// SoftRF-specific settings
 		$scope.SoftRFEnabled = settings.SoftRFEnabled;
+		$scope.hasTracker = $scope.hasTracker || settings.SoftRFEnabled;
 		$scope.SoftRFProtocol = (settings.SoftRFProtocol >= 0) ? settings.SoftRFProtocol.toString() : "7";
 		$scope.SoftRFAltProtocol = (settings.SoftRFAltProtocol >= 0) ? settings.SoftRFAltProtocol.toString() : "0";
 		$scope.SoftRFBand = (settings.SoftRFBand >= 0) ? settings.SoftRFBand.toString() : "2";

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -261,7 +261,8 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 	$scope.$parent.helppage = 'plates/settings-help.html';
 
 	var toggles = ['UAT_Enabled', 'ES_Enabled', 'OGN_Enabled', 'AIS_Enabled', 'APRS_Enabled', 'Ping_Enabled', 'Pong_Enabled', 'OGNI2CTXEnabled', 'GPS_Enabled', 'IMU_Sensor_Enabled',
-		'BMP_Sensor_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'TraceLog', 'AHRSLog', 'PersistentLogging', 'GDL90MSLAlt_Enabled', 'EstimateBearinglessDist', 'DarkMode'];
+		'BMP_Sensor_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'TraceLog', 'AHRSLog', 'PersistentLogging', 'GDL90MSLAlt_Enabled', 'EstimateBearinglessDist', 'DarkMode',
+		'SoftRFEnabled'];
 
 	var settings = {};
 	for (var i = 0; i < toggles.length; i++) {

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -723,12 +723,12 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 	// SoftRF protocol compatibility map
 	var softRFCompatMap = {
-		'7':  {'1':true, '2':true, '5':true, '6':true, '8':true},  // Latest: all others
-		'6':  {'1':true, '7':true, '8':true},                       // Legacy: OGNTP, Latest, ADS-L
-		'1':  {'2':true, '5':true, '6':true, '7':true, '8':true},  // OGNTP: P3I, FANET, Legacy, Latest, ADS-L
+		'7':  {'1':true, '2':true, '5':true, '6':true, '8':true},  // Latest: OGNTP, P3I, FANET, Legacy, ADS-L
+		'6':  {'7':true},                                            // Legacy: Latest only (T-Echo restriction)
+		'1':  {'2':true, '5':true, '7':true, '8':true},             // OGNTP: P3I, FANET, Latest, ADS-L
 		'2':  {'1':true, '7':true, '8':true},                       // P3I: OGNTP, Latest, ADS-L
 		'5':  {'1':true, '7':true, '8':true},                       // FANET: OGNTP, Latest, ADS-L
-		'8':  {'1':true, '2':true, '5':true, '6':true, '7':true},  // ADS-L: all others
+		'8':  {'1':true, '2':true, '5':true, '7':true},             // ADS-L: OGNTP, P3I, FANET, Latest
 	};
 
 	$scope.updateSoftRFCompatProtocols = function() {

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -343,6 +343,17 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.OGNReg = settings.OGNReg;
 		$scope.OGNTxPower = settings.OGNTxPower;
 
+		// SoftRF-specific settings
+		$scope.SoftRFProtocol = (settings.SoftRFProtocol >= 0) ? settings.SoftRFProtocol.toString() : "7";
+		$scope.SoftRFAltProtocol = (settings.SoftRFAltProtocol >= 0) ? settings.SoftRFAltProtocol.toString() : "0";
+		$scope.SoftRFBand = (settings.SoftRFBand >= 0) ? settings.SoftRFBand.toString() : "2";
+		$scope.SoftRFAlarm = (settings.SoftRFAlarm >= 0) ? settings.SoftRFAlarm.toString() : "3";
+		$scope.SoftRFRelay = (settings.SoftRFRelay >= 0) ? settings.SoftRFRelay.toString() : "0";
+		$scope.SoftRFTxPower = (settings.SoftRFTxPower >= 0) ? settings.SoftRFTxPower.toString() : "2";
+		$scope.SoftRFStealth = settings.SoftRFStealth;
+		$scope.SoftRFNoTrack = settings.SoftRFNoTrack;
+		$scope.updateSoftRFCompatProtocols();
+
 		$scope.PWMDutyMin = settings.PWMDutyMin;
 
 		// Update theme
@@ -710,6 +721,26 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		return "???";
 	}
 
+	// SoftRF protocol compatibility map
+	var softRFCompatMap = {
+		'7':  {'1':true, '2':true, '5':true, '6':true, '8':true},  // Latest: all others
+		'6':  {'1':true, '7':true, '8':true},                       // Legacy: OGNTP, Latest, ADS-L
+		'1':  {'2':true, '5':true, '6':true, '7':true, '8':true},  // OGNTP: P3I, FANET, Legacy, Latest, ADS-L
+		'2':  {'1':true, '7':true, '8':true},                       // P3I: OGNTP, Latest, ADS-L
+		'5':  {'1':true, '7':true, '8':true},                       // FANET: OGNTP, Latest, ADS-L
+		'8':  {'1':true, '2':true, '5':true, '6':true, '7':true},  // ADS-L: all others
+	};
+
+	$scope.updateSoftRFCompatProtocols = function() {
+		var proto = $scope.SoftRFProtocol;
+		var allowed = softRFCompatMap[proto] || {};
+		$scope.softRFAltProtoAllowed = allowed;
+		// If current alt selection is no longer valid, reset to None
+		if ($scope.SoftRFAltProtocol !== '0' && !allowed[$scope.SoftRFAltProtocol]) {
+			$scope.SoftRFAltProtocol = '0';
+		}
+	};
+
 	$scope.updateOgnTrackerConfig = function(action) {
 		var newsettings = {
 			"OGNAddrType": parseInt($scope.OGNAddrType),
@@ -719,9 +750,22 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			"OGNReg": $scope.OGNReg,
 			"OGNTxPower": $scope.OGNTxPower
 		};
+
+		// Include SoftRF-specific settings if a SoftRF device is connected
+		if ($scope.gpsHardwareCode == 13) {
+			newsettings["SoftRFProtocol"] = parseInt($scope.SoftRFProtocol);
+			newsettings["SoftRFAltProtocol"] = parseInt($scope.SoftRFAltProtocol);
+			newsettings["SoftRFBand"] = parseInt($scope.SoftRFBand);
+			newsettings["SoftRFAlarm"] = parseInt($scope.SoftRFAlarm);
+			newsettings["SoftRFRelay"] = parseInt($scope.SoftRFRelay);
+			newsettings["SoftRFTxPower"] = parseInt($scope.SoftRFTxPower);
+			newsettings["SoftRFStealth"] = $scope.SoftRFStealth;
+			newsettings["SoftRFNoTrack"] = $scope.SoftRFNoTrack;
+		}
+
 		setSettings(angular.toJson(newsettings));
 
-		// reload settings after a short time, to check if OGN tracker actually accepted the settings
+		// reload settings after a short time, to check if tracker actually accepted the settings
 		setTimeout(function() {
 			getSettings();
 		}, 1000);

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -62,6 +62,8 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 			$scope.AIS_messages_max = status.AIS_messages_max;
 			$scope.AIS_messages_total = status.AIS_messages_total;
 			$scope.AIS_connected = status.AIS_connected;
+			$scope.SoftRF_messages_last_minute = status.SoftRF_messages_last_minute;
+			$scope.SoftRF_messages_max = status.SoftRF_messages_max;
 			$scope.GPS_satellites_locked = status.GPS_satellites_locked;
 			$scope.GPS_satellites_tracked = status.GPS_satellites_tracked;
 			$scope.GPS_satellites_seen = status.GPS_satellites_seen;
@@ -225,6 +227,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 		$scope.uatStyleColor = craftService.getTrafficSourceColor(6);
 		$scope.ognStyleColor = craftService.getTrafficSourceColor(4);
 		$scope.aisStyleColor = craftService.getTrafficSourceColor(5);
+		$scope.softRFStyleColor = craftService.getTrafficSourceColor(7);
 
 		// Simple GET request example (note: responce is asynchronous)
 		$http.get(URL_SETTINGS_GET).
@@ -241,6 +244,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 			$scope.visible_es = settings.ES_Enabled;
 			$scope.visible_ogn = settings.OGN_Enabled;
 			$scope.visible_ais = settings.AIS_Enabled;
+			$scope.visible_softrf = settings.SoftRFEnabled;
 			$scope.visible_ping = settings.Ping_Enabled;
 			$scope.visible_pong = settings.Pong_Enabled;
 			if (settings.Ping_Enabled) {

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -58,6 +58,8 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 			$scope.OGN_messages_max = status.OGN_messages_max;
 			$scope.OGN_messages_total = status.OGN_messages_total;
 			$scope.OGN_connected = status.OGN_connected;
+			$scope.SoftRF_rx_packets = status.SoftRF_rx_packets;
+			$scope.SoftRF_tx_packets = status.SoftRF_tx_packets;
 			$scope.AIS_messages_last_minute = status.AIS_messages_last_minute;
 			$scope.AIS_messages_max = status.AIS_messages_max;
 			$scope.AIS_messages_total = status.AIS_messages_total;
@@ -240,6 +242,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 			$scope.visible_uat = settings.UAT_Enabled;
 			$scope.visible_es = settings.ES_Enabled;
 			$scope.visible_ogn = settings.OGN_Enabled || settings.SoftRFEnabled;
+			$scope.visible_softrf = settings.SoftRFEnabled;
 			$scope.visible_ais = settings.AIS_Enabled;
 			$scope.visible_ping = settings.Ping_Enabled;
 			$scope.visible_pong = settings.Pong_Enabled;

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -62,8 +62,6 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 			$scope.AIS_messages_max = status.AIS_messages_max;
 			$scope.AIS_messages_total = status.AIS_messages_total;
 			$scope.AIS_connected = status.AIS_connected;
-			$scope.SoftRF_messages_last_minute = status.SoftRF_messages_last_minute;
-			$scope.SoftRF_messages_max = status.SoftRF_messages_max;
 			$scope.GPS_satellites_locked = status.GPS_satellites_locked;
 			$scope.GPS_satellites_tracked = status.GPS_satellites_tracked;
 			$scope.GPS_satellites_seen = status.GPS_satellites_seen;
@@ -227,7 +225,6 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 		$scope.uatStyleColor = craftService.getTrafficSourceColor(6);
 		$scope.ognStyleColor = craftService.getTrafficSourceColor(4);
 		$scope.aisStyleColor = craftService.getTrafficSourceColor(5);
-		$scope.softRFStyleColor = craftService.getTrafficSourceColor(7);
 
 		// Simple GET request example (note: responce is asynchronous)
 		$http.get(URL_SETTINGS_GET).
@@ -242,9 +239,8 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 			$scope.DeveloperMode = settings.DeveloperMode;
 			$scope.visible_uat = settings.UAT_Enabled;
 			$scope.visible_es = settings.ES_Enabled;
-			$scope.visible_ogn = settings.OGN_Enabled;
+			$scope.visible_ogn = settings.OGN_Enabled || settings.SoftRFEnabled;
 			$scope.visible_ais = settings.AIS_Enabled;
-			$scope.visible_softrf = settings.SoftRFEnabled;
 			$scope.visible_ping = settings.Ping_Enabled;
 			$scope.visible_pong = settings.Pong_Enabled;
 			if (settings.Ping_Enabled) {

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -60,6 +60,10 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 			$scope.OGN_connected = status.OGN_connected;
 			$scope.SoftRF_rx_packets = status.SoftRF_rx_packets;
 			$scope.SoftRF_tx_packets = status.SoftRF_tx_packets;
+			$scope.SoftRF_rx_FLARM_latest = status.SoftRF_rx_FLARM_latest;
+			$scope.SoftRF_rx_FLARM_legacy = status.SoftRF_rx_FLARM_legacy;
+			$scope.SoftRF_rx_ADSL = status.SoftRF_rx_ADSL;
+			$scope.SoftRF_rx_other = status.SoftRF_rx_other;
 			$scope.AIS_messages_last_minute = status.AIS_messages_last_minute;
 			$scope.AIS_messages_max = status.AIS_messages_max;
 			$scope.AIS_messages_total = status.AIS_messages_total;
@@ -92,6 +96,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 					$scope.GPS_position_accuracy = ", " + status.GPS_position_accuracy.toFixed(1) + " m";
 			}
 			var gpsHardwareCode = (status.GPS_detected_type & 0x0f);
+			$scope.gpsHardwareCode = gpsHardwareCode;
 			var tempGpsHardwareString = "Not installed";
 			switch(gpsHardwareCode) {
 				// Keep in mind that this must be in sync with the enumeration in gen_gdl90.go
@@ -241,8 +246,8 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 			$scope.DeveloperMode = settings.DeveloperMode;
 			$scope.visible_uat = settings.UAT_Enabled;
 			$scope.visible_es = settings.ES_Enabled;
-			$scope.visible_ogn = settings.OGN_Enabled || settings.SoftRFEnabled;
-			$scope.visible_softrf = settings.SoftRFEnabled;
+			$scope.visible_ogn = settings.OGN_Enabled || settings.SoftRFEnabled || ($scope.gpsHardwareCode == 11 || $scope.gpsHardwareCode == 13);
+			$scope.visible_softrf = settings.SoftRFEnabled || ($scope.gpsHardwareCode == 11 || $scope.gpsHardwareCode == 13);
 			$scope.visible_ais = settings.AIS_Enabled;
 			$scope.visible_ping = settings.Ping_Enabled;
 			$scope.visible_pong = settings.Pong_Enabled;

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -142,8 +142,8 @@
                             <input class="col-xs-7" type="number" min="-32" max="31" ng-model="OGNTxPower" />
                         </div>
 
-                        <!-- SoftRF-specific settings (hardware code 13) -->
-                        <div ng-show="gpsHardwareCode==13" class="reset-flow" style="width:100%">
+                        <!-- SoftRF-specific settings (hardware code 13, or HAT enabled) -->
+                        <div ng-show="gpsHardwareCode==13 || SoftRFEnabled" class="reset-flow" style="width:100%">
                             <!-- RF Protocol -->
                             <div class="form-group reset-flow">
                                 <label class="control-label col-xs-5">RF Protocol</label>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -529,6 +529,13 @@
                         </div>
                     </div>
 
+                    <div class="form-group reset-flow">
+                        <label class="control-label col-xs-5">SoftRF-MB LoRa HAT (FLARM/ADS-L)</label>
+                        <div class="col-xs-7">
+                            <ui-switch ng-model='SoftRFEnabled' settings-change></ui-switch>
+                        </div>
+                    </div>
+
                 </div>
             </div>
         </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -143,9 +143,7 @@
                         </div>
 
                         <!-- SoftRF-specific settings (hardware code 13) -->
-                        <div ng-show="gpsHardwareCode==13">
-                            <div class="separator"></div>
-
+                        <div ng-show="gpsHardwareCode==13" class="reset-flow" style="width:100%">
                             <!-- RF Protocol -->
                             <div class="form-group reset-flow">
                                 <label class="control-label col-xs-5">RF Protocol</label>
@@ -199,8 +197,6 @@
                                     <option value="0">Off (receive only)</option>
                                 </select>
                             </div>
-
-                            <div class="separator"></div>
 
                             <!-- Alarm Method -->
                             <div class="form-group reset-flow">

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -136,10 +136,109 @@
                             <label class="control-label col-xs-5">Registration</label>
                             <input class="col-xs-7" type="text" maxlength="15" ognreg-input ng-model="OGNReg" />
                         </div>
-                        <!-- TX Power -->
+                        <!-- TX Power (OGN/GX only) -->
                         <div class="form-group reset-flow" ng-hide="gpsHardwareCode==13 || gpsHardwareCode==15">
                             <label class="control-label col-xs-5">Transmit Power (dBm)<br/><small>-32 = no transmission, actual power depends on hardware</small></label>
                             <input class="col-xs-7" type="number" min="-32" max="31" ng-model="OGNTxPower" />
+                        </div>
+
+                        <!-- SoftRF-specific settings (hardware code 13) -->
+                        <div ng-show="gpsHardwareCode==13">
+                            <div class="separator"></div>
+
+                            <!-- RF Protocol -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">RF Protocol</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFProtocol" ng-change="updateSoftRFCompatProtocols()">
+                                    <option value="7">Latest (FLARM v7)</option>
+                                    <option value="6">Legacy (FLARM v6)</option>
+                                    <option value="1">OGNTP</option>
+                                    <option value="2">P3I (PilotAware)</option>
+                                    <option value="5">FANET</option>
+                                    <option value="8">ADS-L</option>
+                                </select>
+                            </div>
+
+                            <!-- Alternate Protocol -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Alternate Protocol</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFAltProtocol">
+                                    <option value="0">None</option>
+                                    <option value="1" ng-show="softRFAltProtoAllowed['1']">OGNTP</option>
+                                    <option value="2" ng-show="softRFAltProtoAllowed['2']">P3I (PilotAware)</option>
+                                    <option value="5" ng-show="softRFAltProtoAllowed['5']">FANET</option>
+                                    <option value="6" ng-show="softRFAltProtoAllowed['6']">Legacy (FLARM v6)</option>
+                                    <option value="7" ng-show="softRFAltProtoAllowed['7']">Latest (FLARM v7)</option>
+                                    <option value="8" ng-show="softRFAltProtoAllowed['8']">ADS-L</option>
+                                </select>
+                            </div>
+
+                            <!-- RF Band -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">RF Band</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFBand">
+                                    <option value="1">EU (868 MHz)</option>
+                                    <option value="2">US (915 MHz)</option>
+                                    <option value="3">AU (921 MHz)</option>
+                                    <option value="4">NZ (869 MHz)</option>
+                                    <option value="5">RU (868 MHz)</option>
+                                    <option value="6">CN (470 MHz)</option>
+                                    <option value="7">UK (869 MHz)</option>
+                                    <option value="8">IN (866 MHz)</option>
+                                    <option value="9">IL (916 MHz)</option>
+                                    <option value="10">KR (920 MHz)</option>
+                                </select>
+                            </div>
+
+                            <!-- TX Power -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">TX Power</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFTxPower">
+                                    <option value="2">Full</option>
+                                    <option value="1">Low</option>
+                                    <option value="0">Off (receive only)</option>
+                                </select>
+                            </div>
+
+                            <div class="separator"></div>
+
+                            <!-- Alarm Method -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Alarm Method</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFAlarm">
+                                    <option value="3">FLARM</option>
+                                    <option value="2">Vector</option>
+                                    <option value="1">Distance</option>
+                                    <option value="0">None</option>
+                                </select>
+                            </div>
+
+                            <!-- Relay Mode -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Relay Mode</label>
+                                <select class="col-xs-7 custom-select" ng-model="SoftRFRelay">
+                                    <option value="0">Off</option>
+                                    <option value="1">Landed</option>
+                                    <option value="2">All</option>
+                                    <option value="3">Relay only</option>
+                                </select>
+                            </div>
+
+                            <!-- Stealth -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">Stealth</label>
+                                <div class="col-xs-5">
+                                    <ui-switch ng-model='SoftRFStealth'></ui-switch>
+                                </div>
+                            </div>
+
+                            <!-- No Track -->
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">No Track</label>
+                                <div class="col-xs-5">
+                                    <ui-switch ng-model='SoftRFNoTrack'></ui-switch>
+                                </div>
+                            </div>
                         </div>
 
                         <div class="form-group reset-flow">

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -93,7 +93,7 @@
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
 					<div class="col-sm-6">
-						<span><strong>{{visible_softrf ? "SoftRF HAT Statistics" : "OGN Statistics"}}</strong></span>
+						<span><strong>OGN Statistics</strong></span>
 					</div>
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn || visible_softrf}">

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -70,6 +70,15 @@
 					</div></span>
 					<span class="col-xs-2 text-right">{{AIS_messages_max}}</span>
 				</div>
+				<div class="row" ng-class="{'section_invisible': !visible_softrf}">
+					<span class="col-xs-1"></span>
+					<label class="col-xs-3">SoftRF HAT:</label>
+					<span class="col-xs-6"><div class="bar_container">
+						<div class="bar_display" ng-attr-style="background-color: {{softRFStyleColor}}; width:{{SoftRF_messages_max ? 100*SoftRF_messages_last_minute / SoftRF_messages_max : 0}}%;"></div>
+						<div class="bar_text">{{SoftRF_messages_last_minute}}</div>
+					</div></span>
+					<span class="col-xs-2 text-right">{{SoftRF_messages_max}}</span>
+				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
 					<span class="col-xs-1"></span>
 					<label class="col-xs-3">OGN{{OGN_connected ? "" : " (disconnected)"}}:</label>

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -72,7 +72,7 @@
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
 					<span class="col-xs-1"></span>
-					<label class="col-xs-3">{{visible_softrf ? "SoftRF HAT" : ("OGN" + (OGN_connected ? "" : " (disconnected)"))}}:</label>
+					<label class="col-xs-3">{{visible_softrf ? "SoftRF" : ("OGN" + (OGN_connected ? "" : " (disconnected)"))}}:</label>
 					<span class="col-xs-6"><div class="bar_container">
 						<div class="bar_display" ng-attr-style="background-color: {{ognStyleColor}}; width:{{OGN_messages_max ? 100*OGN_messages_last_minute / OGN_messages_max : 0}}%;"></div>
 						<div class="bar_text">{{OGN_messages_last_minute}}</div>
@@ -93,7 +93,7 @@
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
 					<div class="col-sm-6">
-						<span><strong>OGN Statistics</strong></span>
+						<span><strong>{{visible_softrf ? "SoftRF Statistics" : "OGN Statistics"}}</strong></span>
 					</div>
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn || visible_softrf}">
@@ -108,6 +108,22 @@
 						<span align="center" class="col-xs-4">{{OGN_noise_db}} dB</span>
 						<span align="center" class="col-xs-4">{{OGN_gain_db}} dB</span>
 						<span align="center" class="col-xs-4"><a ng-href="{{OGN_Status_url}}">Download</a></span>
+					</div>
+				</div>
+				<div class="row" ng-class="{'section_invisible': !visible_ogn || !visible_softrf}">
+					<div class="col-sm-12">
+						<span align="center" class="col-xs-3 row-header">FLARM Latest</span>
+						<span align="center" class="col-xs-3 row-header">FLARM Legacy</span>
+						<span align="center" class="col-xs-3 row-header">ADS-L</span>
+						<span align="center" class="col-xs-3 row-header">Other</span>
+					</div>
+				</div>
+				<div class="row" ng-class="{'section_invisible': !visible_ogn || !visible_softrf}">
+					<div class="col-sm-12">
+						<span align="center" class="col-xs-3">{{SoftRF_rx_FLARM_latest}}</span>
+						<span align="center" class="col-xs-3">{{SoftRF_rx_FLARM_legacy}}</span>
+						<span align="center" class="col-xs-3">{{SoftRF_rx_ADSL}}</span>
+						<span align="center" class="col-xs-3">{{SoftRF_rx_other}}</span>
 					</div>
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn || !visible_softrf}">

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -72,14 +72,14 @@
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
 					<span class="col-xs-1"></span>
-					<label class="col-xs-3">OGN{{OGN_connected ? "" : " (disconnected)"}}:</label>
+					<label class="col-xs-3">{{visible_softrf ? "SoftRF HAT" : ("OGN" + (OGN_connected ? "" : " (disconnected)"))}}:</label>
 					<span class="col-xs-6"><div class="bar_container">
 						<div class="bar_display" ng-attr-style="background-color: {{ognStyleColor}}; width:{{OGN_messages_max ? 100*OGN_messages_last_minute / OGN_messages_max : 0}}%;"></div>
 						<div class="bar_text">{{OGN_messages_last_minute}}</div>
 					</div></span>
 					<span class="col-xs-2 text-right">{{OGN_messages_max}}</span>
 				</div>
-				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
+				<div class="row" ng-class="{'section_invisible': !visible_ogn || visible_softrf}">
 					<span class="col-xs-1"></span>
 					<label class="col-xs-3">OGN Noise@Gain 50:<br/><sup>Half range for each 6 dB noise</sup></label>
 					<span class="col-xs-6"><div class="bar_container">
@@ -93,21 +93,33 @@
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
 					<div class="col-sm-6">
-						<span><strong>OGN Statistics</strong></span>
+						<span><strong>{{visible_softrf ? "SoftRF HAT Statistics" : "OGN Statistics"}}</strong></span>
 					</div>
 				</div>
-				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
+				<div class="row" ng-class="{'section_invisible': !visible_ogn || visible_softrf}">
 					<div class="col-sm-12">
 						<span align="center" class="col-xs-4 row-header">Background Noise@Gain 50</span>
 						<span align="center" class="col-xs-4 row-header">Receiver Gain</span>
 						<span align="center" class="col-xs-4 row-header">RF Spectrogram</span>
 					</div>
 				</div>
-				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
+				<div class="row" ng-class="{'section_invisible': !visible_ogn || visible_softrf}">
 					<div class="col-sm-12">
 						<span align="center" class="col-xs-4">{{OGN_noise_db}} dB</span>
 						<span align="center" class="col-xs-4">{{OGN_gain_db}} dB</span>
 						<span align="center" class="col-xs-4"><a ng-href="{{OGN_Status_url}}">Download</a></span>
+					</div>
+				</div>
+				<div class="row" ng-class="{'section_invisible': !visible_ogn || !visible_softrf}">
+					<div class="col-sm-12">
+						<span align="center" class="col-xs-6 row-header">Packets Received</span>
+						<span align="center" class="col-xs-6 row-header">Packets Transmitted</span>
+					</div>
+				</div>
+				<div class="row" ng-class="{'section_invisible': !visible_ogn || !visible_softrf}">
+					<div class="col-sm-12">
+						<span align="center" class="col-xs-6">{{SoftRF_rx_packets}}</span>
+						<span align="center" class="col-xs-6">{{SoftRF_tx_packets}}</span>
 					</div>
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_uat}">

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -70,15 +70,6 @@
 					</div></span>
 					<span class="col-xs-2 text-right">{{AIS_messages_max}}</span>
 				</div>
-				<div class="row" ng-class="{'section_invisible': !visible_softrf}">
-					<span class="col-xs-1"></span>
-					<label class="col-xs-3">SoftRF HAT:</label>
-					<span class="col-xs-6"><div class="bar_container">
-						<div class="bar_display" ng-attr-style="background-color: {{softRFStyleColor}}; width:{{SoftRF_messages_max ? 100*SoftRF_messages_last_minute / SoftRF_messages_max : 0}}%;"></div>
-						<div class="bar_text">{{SoftRF_messages_last_minute}}</div>
-					</div></span>
-					<span class="col-xs-2 text-right">{{SoftRF_messages_max}}</span>
-				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ogn}">
 					<span class="col-xs-1"></span>
 					<label class="col-xs-3">OGN{{OGN_connected ? "" : " (disconnected)"}}:</label>


### PR DESCRIPTION
## Summary

Exposes the Moshe-Braner SoftRF fork's full RF configuration (protocol, alt protocol, band, TX power, alarm, relay, stealth, no-track) in the Stratux web UI for hardware code 13, using an atomic-snapshot readback so partial PSRFS responses never half-apply to `globalSettings`.

## Architecture

- **Atomic snapshot readback.** Incoming `$PSRFS` lines are buffered in `tracker.settings`. `globalSettings` is only updated once every required key has arrived, so a slow or noisy serial connection can't leak half-populated state into the UI or config file.
- **Sentinel defaults.** All new int fields default to `-1` (\"not yet read from device\") in `gen_gdl90.go`. Write path and handlers refuse to emit or persist sentinel values; old-config migration resets stale zero values on upgrade.
- **Key-name readiness check.** `isConfigRead()` verifies each required key by name (not a fragile count).
- **Post-readback config apply.** Pending writes are deferred until after the initial readback completes, so the device isn't getting written to mid-conversation during the startup handshake.
- **Re-apply on reconnect.** A device reboot/reconnect triggers a fresh readback and re-applies `globalSettings` from the device, preventing stale state from a prior connection.
- **T-Echo-aware alt protocol map.** The alt-protocol dropdown is filtered by a small compatibility map, so users only see combinations their hardware supports.

## Changes

### `main/gen_gdl90.go`
- New SoftRF fields on `settings`: `SoftRFProtocol`, `SoftRFAltProtocol`, `SoftRFBand`, `SoftRFAlarm`, `SoftRFRelay`, `SoftRFTxPower`, `SoftRFStealth`, `SoftRFNoTrack`
- Int fields default to `-1`; old-config migration resets stale zero values

### `main/tracker.go`
- Atomic snapshot apply of SoftRF settings once all required keys are received
- Query-echo filtering (values of `?` are ignored)
- Readback request iterates a named key list including `tx_power`
- Deferred post-readback config write
- Re-readback + re-apply on reconnect/reboot

### `main/managementinterface.go`
- HTTP handlers for the new SoftRF fields with sentinel-value guards

### `web/plates/js/settings.js`
- Loads SoftRF fields with safe defaults before the device is read
- T-Echo-restricted alt-protocol compatibility map
- Only includes SoftRF settings in the payload when hardware code == 13

### `web/plates/settings.html`
- Context-sensitive labels for SoftRF vs OGN hardware
- All 10 RF bands (EU, US, AU, NZ, RU, CN, UK, IN, IL, KR)
- TX Power control (Full / Low / Off)
- Pilot name and registration visible for SoftRF

## Wire protocol reference (Moshe-Braner fork)

- Protocol values: 1=OGNTP, 2=P3I, 5=FANET, 6=Legacy(FLARMv6), 7=Latest(FLARMv7), 8=ADS-L
- Band values: 1=EU, 2=US, 3=AU, 4=NZ, 5=RU, 6=CN, 7=UK, 8=IN, 9=IL, 10=KR
- TxPower values: 0=off, 1=low, 2=full

## Test plan

- [x] `gofmt` clean on all modified Go files
- [x] Built via CI (`ubuntu-24.04-arm`, `make ddpkg`)
- [x] Deployed and tested on hardware (Pi + Moshe-Braner SoftRF T-Echo via USB serial)
- [x] Full readback populates all keys; no `-1` sentinels leak to API
- [x] Partial/interleaved readback does not prematurely overwrite `globalSettings`
- [x] Single-field write path produces correctly-targeted `$PSRFS` commands
- [x] Service restart re-reads config and re-applies cleanly
- [ ] Reviewer verification on a different SoftRF hardware variant (e.g. ESP32 dev board) would be valuable

## Known limitation (shared with upstream SoftRF protocol)

The SoftRF fork saves+reboots on `$PSRFC,SAV`, so rapid back-to-back settings changes through the UI can land during the device's reboot window and be lost. Hardware testing confirmed this affects multi-field changes issued within ~45 s. A follow-up could either batch writes and emit a single trailing SAV, or gate writes behind an explicit \"Apply\" button. This PR keeps the existing per-field write semantics; the fix is out of scope here but called out for reviewer awareness.