### PR TITLE
Added broadcast output option

### DIFF
--- a/main/clientconnection.go
+++ b/main/clientconnection.go
@@ -39,6 +39,7 @@ type networkConnection struct {
 	Ip              string
 	Port            uint32
 	Capability      uint8
+	Broadcast       bool          `json:"-"` // true when this socket targets the subnet broadcast address
 	Queue           *MessageQueue `json:"-"` // don't store in settings
 
 	LastPingResponse time.Time // last time the client responded
@@ -75,6 +76,10 @@ func (conn *networkConnection) IsThrottled() bool {
 	 Check if a client identifier 'ip:port' is in either a sleep or active state.
 */
 func (conn *networkConnection) IsSleeping() bool {
+	// Broadcast sockets have no per-client ICMP signal; always treat as awake.
+	if conn.Broadcast {
+		return false
+	}
 	// Unable to listen to ICMP without root - send to everything. Just for debugging.
 	if isX86DebugMode() || globalSettings.NoSleep == true {
 		return false
@@ -114,6 +119,9 @@ func (conn *networkConnection) Close() {
 }
 
 func (conn *networkConnection) GetConnectionKey() string {
+	if conn.Broadcast {
+		return "broadcast:" + conn.Ip + ":" + strconv.Itoa(int(conn.Port))
+	}
 	return conn.Ip + ":" + strconv.Itoa(int(conn.Port))
 }
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1197,6 +1197,7 @@ type settings struct {
 	BMP_Sensor_Enabled   bool
 	IMU_Sensor_Enabled   bool
 	NetworkOutputs       []networkConnection
+	NetworkOutputBroadcast bool
 	SerialOutputs        map[string]serialConnection
 	BleOutputs           []bleConnection
 	DisplayTrafficSource bool
@@ -1362,6 +1363,7 @@ func defaultSettings() {
 	globalSettings.DeveloperMode = false
 	globalSettings.StaticIps = make([]string, 0)
 	globalSettings.NoSleep = false
+	globalSettings.NetworkOutputBroadcast = false
 	globalSettings.EstimateBearinglessDist = false
 
 	globalSettings.WiFiChannel = 1

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -562,6 +562,12 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 						setWifiInternetPassthroughEnabled(val.(bool))
 					case "EstimateBearinglessDist":
 						globalSettings.EstimateBearinglessDist = val.(bool)
+					case "NetworkOutputBroadcast":
+						v := val.(bool)
+						if v != globalSettings.NetworkOutputBroadcast {
+							globalSettings.NetworkOutputBroadcast = v
+							rebuildNetworkOutputs()
+						}
 
 					case "OGNAddrType":
 						globalSettings.OGNAddrType = int(val.(float64))

--- a/main/network.go
+++ b/main/network.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/tarm/serial"
@@ -48,6 +49,83 @@ const (
 )
 
 var dhcpLeaseDirectoryLastTest time.Time // Last time fsWriteTest() was run on the DHCP lease directory.
+
+// computeBroadcastAddr returns the directed broadcast address (a.b.c.255) for
+// the AP subnet, derived from globalSettings.WiFiIPAddress. Falls back to
+// 192.168.10.255 if the configured IP cannot be parsed. The /24 mask is
+// always enforced by the AP config (debian/interfaces.template).
+func computeBroadcastAddr() string {
+	ip := net.ParseIP(globalSettings.WiFiIPAddress).To4()
+	if ip == nil {
+		return "192.168.10.255"
+	}
+	return fmt.Sprintf("%d.%d.%d.255", ip[0], ip[1], ip[2])
+}
+
+// dialBroadcastUDP opens a UDP socket pointed at addr with SO_BROADCAST set,
+// which is required by the Linux kernel before writes to a broadcast address
+// will succeed.
+func dialBroadcastUDP(addr string) (*net.UDPConn, error) {
+	d := net.Dialer{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var sockErr error
+			err := c.Control(func(fd uintptr) {
+				sockErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_BROADCAST, 1)
+			})
+			if err != nil {
+				return err
+			}
+			return sockErr
+		},
+	}
+	conn, err := d.Dial("udp4", addr)
+	if err != nil {
+		return nil, err
+	}
+	return conn.(*net.UDPConn), nil
+}
+
+// rebuildNetworkOutputs tears down every existing networkConnection and
+// rebuilds outputs in the currently-configured mode. In broadcast mode it
+// creates one socket per NetworkOutputs entry pointed at the subnet broadcast
+// address. In unicast mode it triggers an immediate DHCP-driven refresh.
+// Safe to call at startup and on settings change.
+func rebuildNetworkOutputs() {
+	netMutex.Lock()
+	for key, conn := range clientConnections {
+		if nc, ok := conn.(*networkConnection); ok {
+			nc.Queue.Close()
+			nc.Conn.Close()
+			delete(clientConnections, key)
+		}
+	}
+	if !globalSettings.NetworkOutputBroadcast {
+		netMutex.Unlock()
+		refreshConnectedClients()
+		return
+	}
+	bcast := computeBroadcastAddr()
+	for _, no := range globalSettings.NetworkOutputs {
+		addr := bcast + ":" + strconv.Itoa(int(no.Port))
+		outConn, err := dialBroadcastUDP(addr)
+		if err != nil {
+			log.Printf("dialBroadcastUDP(%s): %s\n", addr, err.Error())
+			continue
+		}
+		key := "broadcast:" + addr
+		clientConnections[key] = &networkConnection{
+			Conn:       outConn,
+			Ip:         bcast,
+			Port:       no.Port,
+			Capability: no.Capability,
+			Broadcast:  true,
+			Queue:      NewMessageQueue(1024),
+		}
+		go connectionWriter(clientConnections[key])
+		log.Printf("broadcast output created: %s\n", addr)
+	}
+	netMutex.Unlock()
+}
 
 // Read the "dnsmasq.leases" file and parse out IP/hostname.
 func getDHCPLeases() (map[string]string, error) {
@@ -327,6 +405,12 @@ func refreshConnectedClients() {
 	defer netMutex.Unlock()
 
 	dhcpLeases = t
+	// In broadcast mode the network outputs are owned by rebuildNetworkOutputs();
+	// don't create or remove per-client unicast connections here. Lease parsing
+	// above is still kept so the web UI's connected-devices panel works.
+	if globalSettings.NetworkOutputBroadcast {
+		return
+	}
 	// Client connected that wasn't before.
 	for ip, hostname := range dhcpLeases {
 		for _, networkOutput := range globalSettings.NetworkOutputs {
@@ -358,6 +442,9 @@ func refreshConnectedClients() {
 	// Client that was connected before that isn't.
 	for ipAndPort, netconn := range clientConnections {
 		if conn, ok := netconn.(*networkConnection); ok {
+			if conn.Broadcast {
+				continue // broadcast sockets are managed by rebuildNetworkOutputs()
+			}
 			if _, valid := validConnections[ipAndPort]; !valid {
 				log.Printf("removed connection %s.\n", ipAndPort)
 				conn.Queue.Close()
@@ -562,7 +649,10 @@ func icmpEchoSender(c *icmp.PacketConn) {
 		// Collect IPs.
 		ips := make(map[string]bool)
 		for k, conn := range clientConnections {
-			if _, ok := conn.(*networkConnection); ok {
+			if nc, ok := conn.(*networkConnection); ok {
+				if nc.Broadcast {
+					continue // ICMP echoes to a broadcast address are useless
+				}
 				ipAndPort := strings.Split(k, ":")
 				ips[ipAndPort[0]] = true
 			}
@@ -717,6 +807,9 @@ func initNetwork() {
 
 	netMutex = &sync.Mutex{}
 	refreshConnectedClients()
+	if globalSettings.NetworkOutputBroadcast {
+		rebuildNetworkOutputs() // honor persisted broadcast setting at boot
+	}
 	go monitorDHCPLeases() // Checks for new UDP connections
 	go sleepMonitor()
 	go networkStatsCounter()

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -261,7 +261,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 	$scope.$parent.helppage = 'plates/settings-help.html';
 
 	var toggles = ['UAT_Enabled', 'ES_Enabled', 'OGN_Enabled', 'AIS_Enabled', 'APRS_Enabled', 'Ping_Enabled', 'Pong_Enabled', 'OGNI2CTXEnabled', 'GPS_Enabled', 'IMU_Sensor_Enabled',
-		'BMP_Sensor_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'TraceLog', 'AHRSLog', 'PersistentLogging', 'GDL90MSLAlt_Enabled', 'EstimateBearinglessDist', 'DarkMode'];
+		'BMP_Sensor_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'TraceLog', 'AHRSLog', 'PersistentLogging', 'GDL90MSLAlt_Enabled', 'EstimateBearinglessDist', 'NetworkOutputBroadcast', 'DarkMode'];
 
 	var settings = {};
 	for (var i = 0; i < toggles.length; i++) {
@@ -319,6 +319,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.GLimits = settings.GLimits;
 		$scope.GDL90MSLAlt_Enabled = settings.GDL90MSLAlt_Enabled;
 		$scope.EstimateBearinglessDist = settings.EstimateBearinglessDist
+		$scope.NetworkOutputBroadcast = settings.NetworkOutputBroadcast;
 		$scope.StaticIps = settings.StaticIps;
 
 		$scope.WiFiCountry = settings.WiFiCountry;

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -247,6 +247,12 @@
                             <ui-switch ng-model='EstimateBearinglessDist' settings-change></ui-switch>
                         </div>
                     </div>
+                    <div class="form-group reset-flow">
+                        <label class="control-label col-xs-5">Broadcast UDP output to all WiFi clients (instead of per-DHCP-client unicast)</label>
+                        <div class="col-xs-5">
+                            <ui-switch ng-model='NetworkOutputBroadcast' settings-change></ui-switch>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Add NetworkOutputBroadcast setting to send UDP via subnet broadcast

Today Stratux opens one UDP socket per DHCP-leased client per output port and unicasts every GDL90/FFSim/AHRS packet N×M times. Because each socket is dialed to a specific (IP, port) pair, only one process per port can receive the traffic on a given device — running two EFB apps side by side on the same tablet (e.g. ForeFlight and SkyDemon both listening on UDP 4000) means only one of them gets data. Switching to a single subnet-directed broadcast per output port (e.g. 192.168.10.255:4000) lets every app on every connected device receive the same datagrams, also cutting redundant WiFi airtime and letting static-IP / non-DHCP clients receive data without prior discovery.

When the toggle is on:
- One networkConnection per NetworkOutputs entry is dialed to the broadcast address with SO_BROADCAST=1 (via net.Dialer.Control).
- refreshConnectedClients() still parses DHCP leases (so the UI's connected-devices panel keeps working) but skips per-client socket creation and teardown.
- ICMP echo monitoring skips broadcast sockets; IsSleeping() returns false for them since there is no per-client signal to drive sleep detection.

The toggle hot-swaps via a new rebuildNetworkOutputs() helper called from both the /setSettings handler and initNetwork(), so changes take effect immediately and persist across reboots. TCP, BLE, and serial outputs are untouched.