### PR TITLE
Support SoftRF GDL90 traffic input from both GPIO and USB serial devices

### DIFF
--- a/debian/99-softrf.rules
+++ b/debian/99-softrf.rules
@@ -1,0 +1,2 @@
+# Ebyte E80-900MBL-02 with CH340 USB-UART Adapter
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", SYMLINK+="softrf"

--- a/main/gps.go
+++ b/main/gps.go
@@ -310,7 +310,7 @@ func initGPSSerial() bool {
 		device = "/dev/softrf_dongle"
 		globalStatus.GPS_detected_type = GPS_TYPE_SOFTRF_DONGLE
 		baudrates[0] = 115200
- 	} else if _, err := os.Stat("/dev/serial0"); err == nil { 
+ 	} else if !globalSettings.Ping_Enabled { 
 		// ttyS0 is PL011 UART (GPIO pins 8 and 10) on all RPi.
 		// assume that any GPS connected to serial GPIO is ublox
 		device = "/dev/serial0"

--- a/main/ping.go
+++ b/main/ping.go
@@ -41,6 +41,84 @@ var closeCh chan int
 var pingDeviceModel int
 var pingDeviceSuccessfullyWorking bool
 
+func gdl90SerialReader() {
+	defer pingSerialPort.Close()
+
+	log.Printf("Starting SoftRF GDL90 serial reader")
+
+	buf := make([]byte, 256)
+	frame := make([]byte, 0, 512)
+
+	inFrame := false
+	escaped := false
+
+	for globalStatus.Ping_connected && globalSettings.Ping_Enabled {
+
+		n, err := pingSerialPort.Read(buf)
+		if err != nil {
+			log.Printf("SoftRF read error: %v", err)
+			break
+		}
+
+		for i := 0; i < n; i++ {
+
+			b := buf[i]
+
+			if b == 0x7e {
+
+				if inFrame {
+
+					// kompletten Frame erhalten
+					if len(frame) >= 3 {
+
+						// CRC entfernen
+						payload := frame[:len(frame)-2]
+
+						msgType := payload[0]
+
+						switch msgType {
+
+						case 0x14:
+							processSoftRFGDL90Traffic(payload)
+						default:
+							// optional zum Debuggen
+							// log.Printf("Ignoring GDL90 type=0x%02X", msgType)
+						}
+
+
+					}
+
+					frame = frame[:0]
+				}
+
+				inFrame = true
+				continue
+			}
+
+			if inFrame {
+
+				// Escaping nach GDL90
+
+				if escaped {
+					frame = append(frame, b^0x20)
+					escaped = false
+					continue
+				}
+
+				if b == 0x7d {
+					escaped = true
+					continue
+				}
+
+				frame = append(frame, b)
+			}
+		}
+	}
+
+	globalStatus.Ping_connected = false
+	log.Printf("Exiting SoftRF GDL90 serial reader")
+}
+
 func initPingSerial() bool {
 	var device string
 	baudrate := int(2000000)
@@ -50,20 +128,26 @@ func initPingSerial() bool {
 
 	if _, err := os.Stat("/dev/ping"); err == nil {
 		device = "/dev/ping"
+
 	} else if _, err := os.Stat("/dev/softrf"); err == nil {
 		device = "/dev/softrf"
-		baudrate = int(38400)
+		baudrate = 38400
+
+	} else if _, err := os.Stat("/dev/serial0"); err == nil {
+		device = "/dev/serial0"
+		baudrate = 38400
+
 	} else if _, err := os.Stat("/dev/pingusb"); err == nil {
-		// 99-uavionix.rules 0403:6015
 		device = "/dev/pingusb"
-		baudrate = int(57600)
+		baudrate = 57600
 		pingDeviceModel = 1
+
 	} else {
 		log.Printf("No suitable Ping device found.\n")
 		return false
 	}
-	log.Printf("Using %s for Ping\n", device)
 
+	log.Printf("Using %s for Ping\n", device)
 	// Open port
 	// No timeout specified as Ping does not heartbeat
 	pingSerialConfig = &serial.Config{Name: device, Baud: baudrate}
@@ -284,12 +368,18 @@ func pingWatcher() {
 			//count := 0
 			// pingEFB - 1090
 			if globalStatus.Ping_connected && pingDeviceModel == 0 {
-				//pingWG.Add(1)
+
 				go pingNetworkRepeater()
-				//pingNetworkConnection()
-				go pingSerialReader()
-				// Emulate SDR count
-				//count = 2
+
+			  	switch pingSerialConfig.Name {
+			  		case "/dev/softrf", "/dev/serial0":
+						log.Printf("Starting SoftRF GDL90 serial reader")
+						go gdl90SerialReader()
+			  		default:
+						log.Printf("Starting Ping ASCII serial reader")
+						go pingSerialReader()
+			  	}
+
 			}
 			// pingUSB - MavLink
 			if globalStatus.Ping_connected && pingDeviceModel == 1 {

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -172,6 +172,115 @@ var seenTraffic map[uint32]bool // Historical list of all ICAO addresses seen.
 
 var OwnshipTrafficInfo TrafficInfo
 
+func processSoftRFGDL90Traffic(frame []byte) {
+
+	if len(frame) != 28 {
+		log.Printf("Unexpected TYPE14 length=%d", len(frame))
+		return
+	}
+
+	var ti TrafficInfo
+
+	// ICAO-Adresse
+	ti.Icao_addr =
+		uint32(frame[2])<<16 |
+		uint32(frame[3])<<8 |
+		uint32(frame[4])
+
+	// vorhandenen Datensatz übernehmen
+	trafficMutex.Lock()
+	if old, ok := traffic[ti.Icao_addr]; ok {
+		ti = old
+	}
+	trafficMutex.Unlock()
+
+	ti.Addr_type = frame[1] & 0x0f
+
+	// Position
+	ti.Lat = decodeLatLng(frame[5], frame[6], frame[7])
+	ti.Lng = decodeLatLng(frame[8], frame[9], frame[10])
+	ti.Position_valid = true
+
+	if isGPSValid() {
+		ti.Distance, ti.Bearing = common.Distance(
+			float64(mySituation.GPSLatitude),
+			float64(mySituation.GPSLongitude),
+			float64(ti.Lat),
+			float64(ti.Lng),
+		)
+		ti.BearingDist_valid = true
+	}
+
+	// Höhe
+	altCode := (uint16(frame[11]) << 4) | (uint16(frame[12]) >> 4)
+	if altCode != 0x0FFF {
+		ti.Alt = int32(altCode)*25 - 1000
+	}
+
+	// Airborne / Ground
+	ti.OnGround = (frame[12] & 0x08) == 0
+
+	// NIC / NACp
+	ti.NIC = int((frame[13] >> 4) & 0x0F)
+	ti.NACp = int(frame[13] & 0x0F)
+
+	// Geschwindigkeit
+	speed := (uint16(frame[14]) << 4) | (uint16(frame[15]) >> 4)
+	if speed != 0x0FFF {
+		ti.Speed = speed
+		ti.Speed_valid = true
+	}
+
+	// Vertikalgeschwindigkeit
+	vv := (int16(frame[15]&0x0F) << 8) | int16(frame[16])
+	if vv != 0x0800 {
+		if vv&0x0800 != 0 {
+			vv |= ^0x0FFF
+		}
+		ti.Vvel = vv * 64
+	}
+
+	// Kurs
+	if frame[17] != 0xFF {
+		ti.Track = float32(frame[17]) * TRACK_RESOLUTION
+	}
+
+	// Kategorie
+	ti.Emitter_category = frame[18]
+
+	// Rufzeichen
+	if tail := strings.TrimSpace(string(frame[19:27])); tail != "" {
+		ti.Tail = tail
+	}
+
+	ti.Timestamp = time.Now()
+	ti.Last_seen = stratuxClock.Time
+	ti.Last_alt = stratuxClock.Time
+	ti.Last_speed = stratuxClock.Time
+	ti.Last_source = TRAFFIC_SOURCE_UAT
+	ti.ExtrapolatedPosition = false
+
+	trafficMutex.Lock()
+
+	postProcessTraffic(&ti)
+	traffic[ti.Icao_addr] = ti
+
+	registerTrafficUpdate(ti)
+	seenTraffic[ti.Icao_addr] = true
+
+	trafficMutex.Unlock()
+}
+
+func decodeLatLng(b0, b1, b2 byte) float32 {
+	v := int32(b0)<<16 | int32(b1)<<8 | int32(b2)
+
+	if v&0x800000 != 0 {
+		v |= ^0xFFFFFF
+	}
+
+	return float32(v) * LON_LAT_RESOLUTION
+}
+
 func convertFeetToMeters(feet float32) float32 {
 	return feet * 0.3048
 }
@@ -327,6 +436,7 @@ func sendTrafficUpdates() {
 		log.Printf("==================================================================\n")
 	}
 	for key, ti := range traffic { // ForeFlight 7.5 chokes at ~1000-2000 messages depending on iDevice RAM. Practical limit likely around ~500 aircraft without filtering.
+
 		if isGPSValid() && ti.Position_valid {
 			// func distRect(lat1, lon1, lat2, lon2 float64) (dist, bearing, distN, distE float64) {
 			dist, bearing := common.Distance(float64(mySituation.GPSLatitude), float64(mySituation.GPSLongitude), float64(ti.Lat), float64(ti.Lng))
@@ -1031,9 +1141,10 @@ func parseDownlinkReport(s string, signalLevel int) {
 
 	ti.Timestamp = time.Now()
 
-	ti.Last_source = TRAFFIC_SOURCE_UAT
+	ti.Last_source = TRAFFIC_SOURCE_OGN
 	postProcessTraffic(&ti)
 	traffic[ti.Icao_addr] = ti
+
 	registerTrafficUpdate(ti)
 	seenTraffic[ti.Icao_addr] = true // Mark as seen.
 }


### PR DESCRIPTION
Description

This change adds support for using SoftRF GDL90 devices with Stratux.

The primary target is the Ebyte E80-900MBL-02 running SoftRF GDL90 software and connected directly to the Raspberry Pi GPIO serial interface.

It also allows also a T-Beam S3 Core or T-Motion running SoftRF to be connected to Stratux via USB.

The goal is to support SoftRF GDL90 traffic input from both GPIO and USB serial devices without interfering with the existing Stratux GPS functionality.

Changes

    Add support for receiving SoftRF GDL90 data through the Raspberry Pi serial interface.
    Support the Ebyte E80-900MBL-02 connected to the Raspberry Pi GPIO UART or USB UART.
    Add GDL90 frame handling including byte escaping.
    Process GDL90 Traffic Report messages (0x14).
    Decode and pass the traffic information to the existing Stratux traffic handling.
    Adjust serial device selection so that the GPIO serial interface can be used for SoftRF while retaining the existing GPS functionality.
    Add the required udev rule for the SoftRF serial device.

Hardware tested

    Ebyte E80-900MBL-02 connected to Raspberry Pi GPIO or USB UART.
    T-Motion or T-Beam S3 Core connected to Raspberry Pi via USB (already supported).

The SoftRF GDL90 software is used as the source of the GDL90 traffic data.

The received traffic can be displayed by Stratux and is available to connected applications such as XCSoar.